### PR TITLE
Fixed flight mode detection for acro

### DIFF
--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -78,7 +78,7 @@ local function crsf(data)
 		elseif data.fm == "OK" or bfArmed == false then
 			data.mode = 1
 		-- Armed modes
-		elseif data.fm == "ACRO" then
+		elseif data.fm == "ACRO" or data.fm == "AIR" then
 			data.mode = 5
 		elseif data.fm == "ANGL" or data.fm == "STAB" then
 			data.mode = 15


### PR DESCRIPTION
Sometimes “AIR” can be sent over as the flight mode. This should be set to ACRO. Currently it’s not, so will just fall through.