### PR TITLE
Stop abusing system theme (optimised)

### DIFF
--- a/docs/EdgeTX-Compatibility.md
+++ b/docs/EdgeTX-Compatibility.md
@@ -1,0 +1,35 @@
+# Developer Notes - EDGETX Compatibility
+
+## Introduction
+
+This guide describes now to modify the inav Lua Telemetry widget such that it works correctly in both EdgeTX and OpenTX.
+
+EdgeTX is a touch-screen enabled fork of OpenTX. As part of the touch-screen enhancement, EdgeTX has expanded the way that some of the colour LCD APIs function. These changes are described in the [excellent EdgeTX API documenation](https://luadoc.edgetx.org/part_ii_-_opentx_lua_api_programming_guide/drawing-flags-and-colors).
+
+## Summary of changes of the inav Lua widget
+
+In order to keep the inav Lua widget compatible with both EdgeTX and OpenTX, the following are required for code that may run on colour screens.
+
+* Do not modify the indexed colours as these are shared by the system theme and other widgets.
+* Use the new `data.RBG()` function to convert RGB colour definitions to a Lua `COLOR`.
+  - Do not call `lcd.RBG()` directly as it may return `nil` under some circumstances on OpenTX.
+  - Do not use pre-computed integer values for colours; these will not work on EdgeTX.
+* Do not set colours and display flags directly _on colour devices_. Use the new `data.set_flags()` function as this will work correctly on both EdgeTX and OpenTX. It will also work on older monochrome displays, but is unnecesasry in code that will not be executed on a colour device (e.g. `src/SCRIPTS/TELEMETRY/iNav/radar.lua`; note that `src/SCRIPTS/TELEMETRY/iNav/menu.lua` requires some care, it is runs on both colour and monochrome devices.
+
+## Hints and tips
+
+* The project should only contain a single instance of `CUSTOM_COLOR`; this is embedded in `src/SCRIPTS/TELEMETRY/iNav/func_h.lua` and is only used on OpenTX.
+* The project uses its own colour map. It should not contain any other instances of `_COLOR` symbols.
+* The user preference text colour is cached in `data.TextColor`, the user preference warning colour (which the widget modifies) is cached in `data.WarningColor`.
+
+## Examples
+
+```
+local mycol = data.RGB(0, 121, 180)
+local myflags = data.set_flags(MIDSIZE + RIGHT, mycol)
+text(x, y, "A Message", myflags)
+text(x1, y2, "More Text", myflags)
+text(x2, y2, "Something else", data.set_flags(0, data.TextColor))
+-- note we can't use myflags again (at least OpenTX) without resetting the value
+line(x2, y2, x3, y3, SOLID, data.set_flags(0, LIGHTGREY))
+```

--- a/docs/EdgeTX-Compatibility.md
+++ b/docs/EdgeTX-Compatibility.md
@@ -14,7 +14,7 @@ In order to keep the inav Lua widget compatible with both EdgeTX and OpenTX, the
 * Use the new `data.RBG()` function to convert RGB colour definitions to a Lua `COLOR`.
   - Do not call `lcd.RBG()` directly as it may return `nil` under some circumstances on OpenTX.
   - Do not use pre-computed integer values for colours; these will not work on EdgeTX.
-* Do not set colours and display flags directly _on colour devices_. Use the new `data.set_flags()` function as this will work correctly on both EdgeTX and OpenTX. It will also work on older monochrome displays, but is unnecesasry in code that will not be executed on a colour device (e.g. `src/SCRIPTS/TELEMETRY/iNav/radar.lua`; note that `src/SCRIPTS/TELEMETRY/iNav/menu.lua` requires some care, it is runs on both colour and monochrome devices.
+* Do not set colours and display flags directly _on colour devices_. Use the new `data.set_flags()` function as this will work correctly on both EdgeTX and OpenTX. It will also work on older monochrome displays, but is unnecesasry in code that will not be executed on a colour device (e.g. `src/SCRIPTS/TELEMETRY/iNav/radar.lua`); note that `src/SCRIPTS/TELEMETRY/iNav/menu.lua` requires some care, it is runs on both colour and monochrome devices.
 
 ## Hints and tips
 

--- a/src/SCRIPTS/TELEMETRY/iNav.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav.lua
@@ -3,18 +3,17 @@
 -- Docs: https://github.com/iNavFlight/LuaTelemetry
 
 local zone, options = ...
-local VERSION = "2.0.0"
+local VERSION = "2.0.1"
 local FILE_PATH = "/SCRIPTS/TELEMETRY/iNav/"
 local SMLCD = LCD_W < 212
 local HORUS = LCD_W >= 480 or LCD_H >= 480
-local FLASH = HORUS and WARNING_COLOR or 3
 local tmp, view, lang, playLog
 local env = "bt" -- compile on platform
 local inav = {}
 
 local ext = "" -- compile on platform
 
-local v, r, m, i, e = getVersion()
+local v, r, m, i, e, osname = getVersion()
 -- Nirvana NV14 doesn't have have these global constants, so we set them
 if string.sub(r, 0, 4) == "nv14" or string.sub(r, 0, 4) == "NV14" then
 	EVT_SYS_FIRST = 1 --1542
@@ -33,6 +32,8 @@ collectgarbage()
 local data, getTelemetryId, getTelemetryUnit, PREV, NEXT, MENU, text, line, rect, fill, frmt = loadScript(FILE_PATH .. "data" .. ext, env)(r, m, i, HORUS)
 collectgarbage()
 
+data.etx = (osname ~= nil)
+
 loadScript(FILE_PATH .. "load" .. ext, env)(config, data, FILE_PATH)
 collectgarbage()
 
@@ -49,10 +50,10 @@ end
 loadScript(FILE_PATH .. "reset" .. ext, env)(data)
 collectgarbage()
 
-local crsf, distCalc = loadScript(FILE_PATH .. "other" .. ext, env)(config, data, units, getTelemetryId, getTelemetryUnit, FILE_PATH, env, SMLCD, FLASH)
+local crsf, distCalc = loadScript(FILE_PATH .. "other" .. ext, env)(config, data, units, getTelemetryId, getTelemetryUnit, FILE_PATH, env, SMLCD)
 collectgarbage()
 
-local title, gpsDegMin, hdopGraph, icons, rect = loadScript(FILE_PATH .. "func_" .. (HORUS and "h" or "t") .. ext, env)(config, data, modes, dir, SMLCD, FILE_PATH, text, line, rect, fill, frmt)
+local title, gpsDegMin, hdopGraph, icons, rect = loadScript(FILE_PATH .. "func_" .. (HORUS and "h" or "t") .. ext, env)(config, data, modes, dir, SMLCD, FILE_PATH, text, line, rect, fill, frmt, options)
 collectgarbage()
 
 local function playAudio(f, a)
@@ -97,7 +98,6 @@ function inav.background()
 	data.rssi, data.rssiLow, data.rssiCrit = getRSSI()
 	if data.rssi > 0 then
 		data.telem = true
-		data.telemFlags = 0
 		data.rssiMin = math.min(data.rssiMin, data.rssi)
 		data.satellites = getValue(data.sat_id)
 		if data.showFuel then
@@ -143,7 +143,6 @@ function inav.background()
 		end
 	else
 		data.telem = false
-		data.telemFlags = FLASH
 	end
 	data.txBatt = getValue(data.txBatt_id)
 	data.throttle = getValue(data.thr_id)
@@ -447,7 +446,6 @@ function inav.run(event)
 	--[[ Show FPS
 	data.start = getTime()
 	]]
-
 	-- Insure background() has run before rendering screen
 	if not data.bkgd then
 		inav.background()
@@ -457,11 +455,6 @@ function inav.run(event)
 	-- Startup message
 	if data.startup == 1 then
 		data.startupTime = getTime()
-		if HORUS then
-		   data.saveZero = lcd.getColor(0)
-		   data.saveText = lcd.getColor(TEXT_COLOR)
-		   data.saveWarn = lcd.getColor(WARNING_COLOR)
-		end
 		data.startup = 2
 	elseif data.startup == 2 and getTime() - data.startupTime >= 200 then
 		data.startup = 0
@@ -475,10 +468,6 @@ function inav.run(event)
 			data.nfs()
 			return 0
 		end
-		-- set user preference colours
-		lcd.setColor(0,  options.Text)
-		lcd.setColor(TEXT_COLOR,  options.Text)
-		lcd.setColor(WARNING_COLOR, options.Warning)
 		-- On Horus use sticks to control the menu
 		event = data.clear(event)
 	else
@@ -502,9 +491,9 @@ function inav.run(event)
 			data.v = 9
 		end
 		tmp = config[30].v
-		view(data, config, units, lang, event, gpsDegMin, getTelemetryId, getTelemetryUnit, SMLCD, FLASH, PREV, NEXT, HORUS, text, rect, fill, frmt, env)
+		view(data, config, units, lang, event, gpsDegMin, getTelemetryId, getTelemetryUnit, SMLCD, PREV, NEXT, HORUS, text, rect, fill, frmt, env)
 		if HORUS then
-			data.menu(tmp)
+		   data.menu(tmp)
 		end
 		-- Exit menu or select log for playback, save config settings
 		if data.configSelect == 0 and (event == EVT_EXIT_BREAK or (event == EVT_ENTER_BREAK and data.configStatus == 34 and config[34].x > -1 and not data.armed)) then
@@ -539,19 +528,12 @@ function inav.run(event)
 			view = loadScript(FILE_PATH .. (HORUS and (data.nv and "nirvana" or "horus") or (config[25].v == 0 and "view" or (config[25].v == 1 and "pilot" or (config[25].v == 2 and "radar" or "alt")))) .. ext, env)()
 			data.v = config[25].v
 		end
-		view(data, config, modes, dir, units, labels, gpsDegMin, hdopGraph, icons, calcBearing, calcDir, VERSION, SMLCD, FLASH, FILE_PATH, text, line, rect, fill, frmt)
+		view(data, config, modes, dir, units, labels, gpsDegMin, hdopGraph, icons, calcBearing, calcDir, VERSION, SMLCD, FILE_PATH, text, line, rect, fill, frmt)
 	end
 	collectgarbage()
 
 	-- Paint title
 	title()
-
-	if HORUS then
-	   lcd.setColor(0, data.saveZero)
-	   lcd.setColor(TEXT_COLOR, data.saveText)
-	   lcd.setColor(WARNING_COLOR, data.saveWarn)
-	end
-
 	return 0
 end
 

--- a/src/SCRIPTS/TELEMETRY/iNav.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav.lua
@@ -23,6 +23,11 @@ if string.sub(r, 0, 4) == "nv14" or string.sub(r, 0, 4) == "NV14" then
 	EVT_EXIT_BREAK = 5 --516
 end
 
+--[[ if string.sub(r, -4) == "simu" then
+   env = "btd"
+   end
+]]
+
 local config = loadScript(FILE_PATH .. "config" .. ext, env)(SMLCD)
 collectgarbage()
 

--- a/src/SCRIPTS/TELEMETRY/iNav/alt.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/alt.lua
@@ -1,8 +1,9 @@
-local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGraph, icons, calcBearing, calcDir, VERSION, SMLCD, FLASH, FILE_PATH, text, line, rect, fill, frmt)
+local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGraph, icons, calcBearing, calcDir, VERSION, SMLCD, FILE_PATH, text, line, rect, fill, frmt)
 	local LEFT_DIV = 36
 	local LEFT_POS = SMLCD and LEFT_DIV or 73
 	local RIGHT_POS = SMLCD and LCD_W - 31 or LCD_W - 53
 	local X_CNTR = (RIGHT_POS + LEFT_POS) * 0.5 - 1
+	local FLASH =  3 -- legacy value
 	local gpsFlags = SMLSIZE + RIGHT + ((not data.telem or not data.gpsFix) and FLASH or 0)
 	local tmp, pitch
 
@@ -29,6 +30,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	end
 	pitch = pitch >= 0 and (pitch < 1 and 0 or math.floor(pitch + 0.5)) or (pitch > -1 and 0 or math.ceil(pitch - 0.5))
 
+	local telemFlag = data.telem and 0 or FLASH
 	-- Bottom center
 	if SMLCD then
 		if data.showDir then
@@ -39,7 +41,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			line(LEFT_POS + 31, 48, LEFT_POS + 31, 63, SOLID, FORCE)
 			-- Distance
 			tmp = data.showMax and data.distanceMax or data.distanceLast
-			text(LEFT_POS + 29, 57, tmp < 1000 and math.floor(tmp + 0.5) .. units[data.dist_unit] or (frmt("%.1f", tmp / (data.dist_unit == 9 and 1000 or 5280)) .. (data.dist_unit == 9 and "km" or "mi")), SMLSIZE + RIGHT + data.telemFlags)
+			text(LEFT_POS + 29, 57, tmp < 1000 and math.floor(tmp + 0.5) .. units[data.dist_unit] or (frmt("%.1f", tmp / (data.dist_unit == 9 and 1000 or 5280)) .. (data.dist_unit == 9 and "km" or "mi")), SMLSIZE + RIGHT + telemFlag)
 			text(LEFT_POS + 10, 49, "Dist", SMLSIZE)
 			icons.home(LEFT_POS + 2, 49)
 			-- Altitude
@@ -83,7 +85,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		if not SMLCD and data.telem then
 			if data.showDir or data.headingRef == -1 then
 				text(LEFT_POS + 12, 29, dir[0], SMLSIZE)
-				text(LEFT_POS + 25 - (data.heading < 100 and 3 or 0) - (data.heading < 10 and 3 or 0), 57, math.floor(data.heading + 0.5) % 360 .. "\64", SMLSIZE + RIGHT + data.telemFlags)
+				text(LEFT_POS + 25 - (data.heading < 100 and 3 or 0) - (data.heading < 10 and 3 or 0), 57, math.floor(data.heading + 0.5) % 360 .. "\64", SMLSIZE + RIGHT + telemFlag)
 				tmp = data.heading
 			else
 				tmp = data.heading - data.headingRef
@@ -119,10 +121,10 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	end
 
 	-- Right data - GPS
-	text(LCD_W, data.crsf and 20 or 8, data.satellites % 100, MIDSIZE + RIGHT + data.telemFlags)
+	text(LCD_W, data.crsf and 20 or 8, data.satellites % 100, MIDSIZE + RIGHT + telemFlag)
 	icons.gps(LCD_W - (SMLCD and 23 or 22), data.crsf and 24 or 12)
 	if data.crsf then
-		text(LCD_W, SMLCD and 9 or 11, data.tpwr < 1000 and data.tpwr .. "mW" or data.tpwr * 0.001 .. "W", SMLSIZE + RIGHT + data.telemFlags)
+		text(LCD_W, SMLCD and 9 or 11, data.tpwr < 1000 and data.tpwr .. "mW" or data.tpwr * 0.001 .. "W", SMLSIZE + RIGHT + telemFlag)
 	else
 		text(LCD_W + 1, SMLCD and 43 or 24, math.floor(data.gpsAlt + 0.5) .. units[data.gpsAlt_unit], gpsFlags)
 	end
@@ -161,12 +163,12 @@ end
 	text(LEFT_DIV, data.showCurr and 34 or 41, "V", SMLSIZE + RIGHT + tmp)
 	if data.showCurr then
 		tmp = data.showMax and data.currentMax or data.current
-		text(LEFT_DIV - 5, 42, tmp >= 99.5 and math.floor(tmp + 0.5) or frmt("%.1f", tmp), MIDSIZE + RIGHT + data.telemFlags)
-		text(LEFT_DIV, 47, "A", SMLSIZE + RIGHT + data.telemFlags)
+		text(LEFT_DIV - 5, 42, tmp >= 99.5 and math.floor(tmp + 0.5) or frmt("%.1f", tmp), MIDSIZE + RIGHT + telemFlag)
+		text(LEFT_DIV, 47, "A", SMLSIZE + RIGHT + telemFlag)
 	end
 	line(0, data.showCurr and 55 or 53, LEFT_DIV, data.showCurr and 55 or 53, SOLID, FORCE)
 	tmp = data.showMax and data.speedMax or data.speed
-	text(LEFT_DIV, data.showCurr and 57 or 56, tmp >= 99.5 and math.floor(tmp + 0.5) .. units[data.speed_unit] or frmt("%.1f", tmp) .. units[data.speed_unit], SMLSIZE + RIGHT + data.telemFlags)
+	text(LEFT_DIV, data.showCurr and 57 or 56, tmp >= 99.5 and math.floor(tmp + 0.5) .. units[data.speed_unit] or frmt("%.1f", tmp) .. units[data.speed_unit], SMLSIZE + RIGHT + telemFlag)
 
 	-- Left data - Wide screen
 	if not SMLCD then
@@ -184,13 +186,13 @@ end
 		tmp = data.showMax and data.distanceMax or data.distanceLast
 		tmp2 = data.dist_unit == 9 and (tmp < 1000 and 6 or 11) or (tmp < 1000 and 2 or 10)
 		text(LEFT_DIV + 2, 30, "Dist", SMLSIZE)
-		text(LEFT_POS - tmp2, (data.dist_unit == 9 or tmp >= 1000) and 42 or 38, tmp < 1000 and units[data.dist_unit] or (data.dist_unit == 9 and "km" or "mi"), SMLSIZE + data.telemFlags)
-		text(LEFT_POS - tmp2, 37, tmp < 1000 and math.floor(tmp + 0.5) or frmt("%.1f", tmp / (data.dist_unit == 9 and 1000 or 5280)), MIDSIZE + RIGHT + data.telemFlags)
+		text(LEFT_POS - tmp2, (data.dist_unit == 9 or tmp >= 1000) and 42 or 38, tmp < 1000 and units[data.dist_unit] or (data.dist_unit == 9 and "km" or "mi"), SMLSIZE + telemFlag)
+		text(LEFT_POS - tmp2, 37, tmp < 1000 and math.floor(tmp + 0.5) or frmt("%.1f", tmp / (data.dist_unit == 9 and 1000 or 5280)), MIDSIZE + RIGHT + telemFlag)
 		--Pitch
 		line(LEFT_DIV, 50, LEFT_POS, 50, SOLID, FORCE)
 		text(LEFT_DIV + 5, 54, pitch > 0 and "\194" or (pitch == 0 and "->" or "\195"), SMLSIZE)
-		text(LEFT_POS, 53, "\64", SMLSIZE + RIGHT + data.telemFlags)
-		text(LEFT_POS - 4, 52, pitch, MIDSIZE + RIGHT + data.telemFlags)
+		text(LEFT_POS, 53, "\64", SMLSIZE + RIGHT + telemFlag)
+		text(LEFT_POS - 4, 52, pitch, MIDSIZE + RIGHT + telemFlag)
 	end
 end
 

--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -1,4 +1,4 @@
-local config, data, getTelemetryId, FLASH = ...
+local config, data, getTelemetryId = ...
 
 data.crsf = true
 data.rfmd_id = getTelemetryId("RFMD")
@@ -23,7 +23,6 @@ local function crsf(data)
 	if getValue(data.rssi_id) == 0 then
 		data.rssi = 0
 		data.telem = false
-		data.telemFlags = FLASH
 		return 0
 	end
 	if data.rssi == 99 then data.rssi = 100 end

--- a/src/SCRIPTS/TELEMETRY/iNav/data.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/data.lua
@@ -83,7 +83,6 @@ local data = {
 	headFree = false,
 	headingHold = false,
 	altHold = false,
-	telemFlags = 0,
 	config = 0,
 	configLast = 1,
 	configTop = 1,

--- a/src/SCRIPTS/TELEMETRY/iNav/func_h.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/func_h.lua
@@ -6,10 +6,10 @@ data.WarningColor = opts.Warn
 function data.set_flags(flag, color)
    local rflag
    if data.etx then
-      rflag  = flag + color -- bit32.bor(flag, color)
+      rflag  = bit32.bor(flag, color) -- flag + color
    else
       lcd.setColor(CUSTOM_COLOR, color)
-      rflag = flag + CUSTOM_COLOR --bit32.bor(flag, CUSTOM_COLOR)
+      rflag = bit32.bor(flag, CUSTOM_COLOR) -- flag + CUSTOM_COLOR
    end
    return rflag
 end
@@ -17,6 +17,7 @@ end
 local function title()
 	local color = lcd.setColor
 	local tmp = data.TextColor
+	local flags = 0
 
 	if not data.telem then
 	   tmp = data.WarningColor
@@ -31,8 +32,9 @@ local function title()
 	-- TX battery
 	local bat = data.nv and 135 or 197
 	if config[19].v > 0 then
-	   fill(bat, 3, 43, 14, data.set_flags(0, data.TextColor))
-	   fill(bat + 43, 6, 2, 8, data.set_flags(0, data.TextColor))
+	   flags = data.set_flags(0, data.TextColor)
+	   fill(bat, 3, 43, 14, flags)
+	   fill(bat + 43, 6, 2, 8, flags)
 	   local lev = math.max(math.min((data.txBatt - data.txBattMin) / (data.txBattMax - data.txBattMin) * 42, 42), 0) + bat
 	   for i = bat + 3, lev, 4 do
 	      fill(i, 5, 2, 10, data.set_flags(0,BLACK))
@@ -62,8 +64,9 @@ local function title()
 	if data.configStatus > 0 then
 	   local dkgrey = data.RGB(49, 48, 49)
 	   fill(0, 30, 75, (22 * (data.crsf and 1 or 2)) + 14, data.set_flags(0, dkgrey))
-	   rect(0, 30, 75, (22 * (data.crsf and 1 or 2)) + 14, data.set_flags(0, data.TextColor))
-	   text(4, 37, "Sats:", data.set_flags(0, data.TextColor))
+	   flags = data.set_flags(0, data.TextColor)
+	   rect(0, 30, 75, (22 * (data.crsf and 1 or 2)) + 14, flags)
+	   text(4, 37, "Sats:", flags)
 	   text(72, 37, data.satellites % 100, data.set_flags(RIGHT, tmp))
 	   if not data.crsf then
 	      text(4, 59, "DOP:", data.set_flags(0, data.TextColor))

--- a/src/SCRIPTS/TELEMETRY/iNav/func_h.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/func_h.lua
@@ -1,68 +1,81 @@
-local config, data, modes, dir, SMLCD, FILE_PATH, text, line, rect, fill, frmt = ...
+local config, data, modes, dir, SMLCD, FILE_PATH, text, line, rect, fill, frmt, opts = ...
+
+data.TextColor = opts.Text
+data.WarningColor = opts.Warn
+
+function data.set_flags(flag, color)
+   local rflag
+   if data.etx then
+      rflag  = flag + color -- bit32.bor(flag, color)
+   else
+      lcd.setColor(CUSTOM_COLOR, color)
+      rflag = flag + CUSTOM_COLOR --bit32.bor(flag, CUSTOM_COLOR)
+   end
+   return rflag
+end
 
 local function title()
 	local color = lcd.setColor
-	local tmp = 0
+	local tmp = data.TextColor
 
 	if not data.telem then
-		tmp = WARNING_COLOR
+	   tmp = data.WarningColor
 	end
 
 	-- Title
-	color(CUSTOM_COLOR, BLACK)
-	fill(0, 0, LCD_W, 20, CUSTOM_COLOR)
+	fill(0, 0, LCD_W, 20, data.set_flags(0,BLACK))
 
 	-- Model
-	text(0, 0, model.getInfo().name)
+	text(0, 0, model.getInfo().name, data.set_flags(0, data.TextColor))
 
 	-- TX battery
 	local bat = data.nv and 135 or 197
 	if config[19].v > 0 then
-		fill(bat, 3, 43, 14, TEXT_COLOR)
-		fill(bat + 43, 6, 2, 8, TEXT_COLOR)
-		local lev = math.max(math.min((data.txBatt - data.txBattMin) / (data.txBattMax - data.txBattMin) * 42, 42), 0) + bat
-		for i = bat + 3, lev, 4 do
-			fill(i, 5, 2, 10, CUSTOM_COLOR)
-		end
+	   fill(bat, 3, 43, 14, data.set_flags(0, data.TextColor))
+	   fill(bat + 43, 6, 2, 8, data.set_flags(0, data.TextColor))
+	   local lev = math.max(math.min((data.txBatt - data.txBattMin) / (data.txBattMax - data.txBattMin) * 42, 42), 0) + bat
+	   for i = bat + 3, lev, 4 do
+	      fill(i, 5, 2, 10, data.set_flags(0,BLACK))
+	   end
 	end
 	if config[19].v ~= 1 then
-		text(data.nv and 180 or bat + 93, 0, frmt("%.1fV", data.txBatt), RIGHT)
+	   text(data.nv and 180 or bat + 93, 0, frmt("%.1fV", data.txBatt), data.set_flags(RIGHT, data.TextColor))
 	end
 
 	-- Timer
 	if config[13].v > 0 then
 		if data.doLogs and data.time ~= nil then
-			text(data.nv and 184 or 340, 0, data.time, WARNING_COLOR)
+		   text(data.nv and 184 or 340, 0, data.time, data.set_flags(0, data.TextColor))
 		else
-			lcd.drawTimer(data.nv and 202 or 340, 0, data.timer)
+		   lcd.drawTimer(data.nv and 202 or 340, 0, data.timer, data.set_flags(0,data.TextColor))
 		end
 	end
 
 	-- Receiver voltage or Crossfire speed
 	if data.rxBatt > 0 and config[14].v == 1 then
-		text(LCD_W, 0, frmt("%.1fV", data.rxBatt), RIGHT + tmp)
+	   text(LCD_W, 0, frmt("%.1fV", data.rxBatt), data.set_flags(RIGHT, tmp))
 	elseif data.crsf then
-		text(LCD_W, 0, (data.rfmd == 2 and 150 or (data.telem and 50 or "--")) .. "Hz", RIGHT + tmp)
+	   text(LCD_W, 0, (data.rfmd == 2 and 150 or (data.telem and 50 or "--")) .. "Hz", data.set_flags(RIGHT,tmp))
 	end
 
 	-- Data on config menu
 	if data.configStatus > 0 then
-		color(CUSTOM_COLOR, data.RGB(49, 48, 49)) -- Dark grey
-		fill(0, 30, 75, (22 * (data.crsf and 1 or 2)) + 14, CUSTOM_COLOR)
-		rect(0, 30, 75, (22 * (data.crsf and 1 or 2)) + 14, TEXT_COLOR)
-		text(4, 37, "Sats:", 0)
-		text(72, 37, data.satellites % 100, RIGHT + tmp)
-		if not data.crsf then
-			text(4, 59, "DOP:", 0)
-			text(72, 59, (data.hdop == 0 and not data.gpsFix) and "---" or (9 - data.hdop) * 0.5 + 0.8, RIGHT + tmp)
-		end
+	   local dkgrey = data.RGB(49, 48, 49)
+	   fill(0, 30, 75, (22 * (data.crsf and 1 or 2)) + 14, data.set_flags(0, dkgrey))
+	   rect(0, 30, 75, (22 * (data.crsf and 1 or 2)) + 14, data.set_flags(0, data.TextColor))
+	   text(4, 37, "Sats:", data.set_flags(0, data.TextColor))
+	   text(72, 37, data.satellites % 100, data.set_flags(RIGHT, tmp))
+	   if not data.crsf then
+	      text(4, 59, "DOP:", data.set_flags(0, data.TextColor))
+	      text(72, 59, (data.hdop == 0 and not data.gpsFix) and "---" or (9 - data.hdop) * 0.5 + 0.8, data.set_flags(RIGHT, tmp))
+	   end
 	end
 
 	--[[ Show FPS ]]
 	if data.nv then
 		data.frames = data.frames + 1
 		--text(data.nv and 75 or 130, 0, frmt("%.1f", math.min(100 / (getTime() - data.start), 20)), RIGHT)
-		text(data.nv and 115 or 180, 0, frmt("%.1f", data.frames / (getTime() - data.fpsStart) * 100), RIGHT)
+		text(data.nv and 115 or 180, 0, frmt("%.1f", data.frames / (getTime() - data.fpsStart) * 100), data.set_flags(RIGHT,data.TextColor))
 	end
 
 end
@@ -74,12 +87,12 @@ local function gpsDegMin(c, lat)
 end
 
 local function hdopGraph(x, y)
-	lcd.setColor(CUSTOM_COLOR, data.hdop < 11 - config[21].v * 2 and YELLOW or WHITE)
+	local ctmp = data.hdop < 11 - config[21].v * 2 and YELLOW or WHITE
 	for i = 4, 9 do
 		if i > data.hdop then
-			lcd.setColor(CUSTOM_COLOR, data.RGB(131, 137, 148))
+		   ctmp = data.RGB(131, 137, 148)
 		end
-		fill(i * 4 + x - 16, y - (i * 3 - 10), 2, i * 3 - 10, CUSTOM_COLOR)
+		fill(i * 4 + x - 16, y - (i * 3 - 10), 2, i * 3 - 10, data.set_flags(0, ctmp))
 	end
 end
 
@@ -118,7 +131,7 @@ if type(iNavZone) == "table" and type(iNavZone.zone) ~= "nil" then
 	if iNavZone.zone.w < (data.nv and 280 or 450) or iNavZone.zone.h < (data.nv and 450 or 250) then
 		data.startupTime = math.huge
 		function data.nfs()
-			text(iNavZone.zone.x + 14, iNavZone.zone.y + 16, "Full screen required", SMLSIZE + WARNING_COLOR)
+		   text(iNavZone.zone.x + 14, iNavZone.zone.y + 16, "Full screen required", data.set_flags(SMLSIZE, data.WarningColor))
 		end
 	end
 end
@@ -136,10 +149,9 @@ if data.nv then
 end
 
 function data.clear(event)
-	lcd.setColor(CUSTOM_COLOR, data.nv and (data.configStatus > 0 and data.RGB(98, 106, 115) or data.RGB(50, 82, 115)) or data.RGB(0, 32, 65))
-	lcd.clear(CUSTOM_COLOR)
-	lcd.setColor(TEXT_COLOR, WHITE)
-	lcd.setColor(WARNING_COLOR, data.telem and (data.nv and data.RGB(255, 255, 100) or YELLOW) or (data.nv and data.RGB(255, 100, 100) or RED)) --lcd.RGB(255, 255, 100) / lcd.RGB(255, 100, 100)
+   local bcol = data.nv and (data.configStatus > 0 and data.RGB(98, 106, 115) or data.RGB(50, 82, 115)) or data.RGB(0, 32, 65)
+   lcd.clear(data.set_flags(0, bcol))
+   data.WarningColor = data.telem and (data.nv and data.RGB(255, 255, 100) or YELLOW) or (data.nv and data.RGB(255, 100, 100) or RED) --lcd.RGB(255, 255, 100) / lcd.RGB(255, 100, 100)
 
 	if event == 0 or event == nil then
 		event = 0
@@ -189,20 +201,18 @@ function data.menu(prev)
 
 	-- Aircraft symbol preview
 	if data.configStatus == 27 and data.configSelect ~= 0 then
-                lcd.setColor(CUSTOM_COLOR, data.nv and data.RGB(49, 170, 230) or data.RGB(0, 121, 180) ) -- Sky
-		fill(LCD_W - 124, (data.nv and 28 or 111), 123, 31, CUSTOM_COLOR)
-                lcd.setColor(CUSTOM_COLOR, data.nv and data.RGB(148, 117, 57) or data.RGB(98, 68, 8)) -- Ground
-		fill(LCD_W - 124, (data.nv and 59 or 142), 123, 31, CUSTOM_COLOR)
-		lcd.drawBitmap(icons.fg, LCD_W - 125, (data.nv and 27 or 110), 50)
-		rect(LCD_W - 125, (data.nv and 27 or 110), 125, 64, TEXT_COLOR)
+	   local scol = data.nv and data.RGB(49, 170, 230) or data.RGB(0, 121, 180)
+	   fill(LCD_W - 124, (data.nv and 28 or 111), 123, 31, data.set_flags(0, scol))
+	   local gcol = data.nv and data.RGB(148, 117, 57) or data.RGB(98, 68, 8)
+	   fill(LCD_W - 124, (data.nv and 59 or 142), 123, 31, data.set_flags(0, gcol))
+	   lcd.drawBitmap(icons.fg, LCD_W - 125, (data.nv and 27 or 110), 50)
+	   rect(LCD_W - 125, (data.nv and 27 or 110), 125, 64, data.set_flags(0,data.TextColor))
 	end
 	-- Return throttle stick to bottom center
 	if data.stickMsg ~= nil and not data.armed then
-		lcd.setColor(CUSTOM_COLOR, BLACK)
-		fill(data.nv and 6 or 20, data.nv and 270 or 128, data.nv and 308 or 439, 30, CUSTOM_COLOR)
-		lcd.setColor(CUSTOM_COLOR, YELLOW)
-		rect(data.nv and 5 or 19, data.nv and 269 or 127, data.nv and 310 or 441, 32, CUSTOM_COLOR)
-		text(data.nv and 14 or 28, data.nv and 275 or 128, data.stickMsg, (data.nv and SMLSIZE or MIDSIZE) + CUSTOM_COLOR)
+	   fill(data.nv and 6 or 20, data.nv and 270 or 128, data.nv and 308 or 439, 30, data.set_flags(0, BLACK))
+	   rect(data.nv and 5 or 19, data.nv and 269 or 127, data.nv and 310 or 441, 32, data.set_flags(0, YELLOW))
+	   text(data.nv and 14 or 28, data.nv and 275 or 128, data.stickMsg, data.set_flags(data.nv and SMLSIZE or MIDSIZE, YELLOW))
 	end
 end
 

--- a/src/SCRIPTS/TELEMETRY/iNav/func_t.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/func_t.lua
@@ -1,5 +1,12 @@
 local config, data, modes, dir, SMLCD, FILE_PATH, text, line, rect, fill, frmt = ...
 
+
+data.TextColor = 0
+data.WarningColor = WARNING_COLOR
+function data.set_flags(flag, color)
+   return flag
+end
+
 local function title()
 	fill(0, 0, LCD_W, 8, FORCE)
 	text(0, 0, model.getInfo().name, INVERS)

--- a/src/SCRIPTS/TELEMETRY/iNav/horus.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/horus.lua
@@ -1,4 +1,4 @@
-local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGraph, icons, calcBearing, calcDir, VERSION, SMLCD, FLASH, FILE_PATH, text, line, rect, fill, frmt)
+local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGraph, icons, calcBearing, calcDir, VERSION, SMLCD, FILE_PATH, text, line, rect, fill, frmt)
 
 	local rgb = data.RGB
 	local SKY = rgb(0, 121, 180)
@@ -61,10 +61,10 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			local yd = cos(roll1) * r
 			local x1, y1, x2, y2 = x - xd, y + yd, x + xd, y - yd
 			if (y1 > top2 or y2 > top2) and (y1 < bot2 or y2 < bot2) and x1 >= 0 and x2 >= 0 then
-				color(CUSTOM_COLOR, r == 20 and WHITE or LIGHTGREY)
-				line(x1, y1, x2, y2, SOLID, CUSTOM_COLOR)
+				local lcol = r == 20 and WHITE or LIGHTGREY
+				line(x1, y1, x2, y2, SOLID, data.set_flags(0, lcol))
 				if r == 20 and y1 > top2 and y1 < bot2 then
-					text(x1 - 1, y1 - 8, upsideDown and -adj or adj, SMLSIZE + RIGHT)
+				   text(x1 - 1, y1 - 8, upsideDown and -adj or adj, data.set_flags(SMLSIZE + RIGHT,data.TextColor))
 				end
 			end
 		end
@@ -75,9 +75,9 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		for i = tmp - 40, tmp, 5 do
 			local tmp2 = Y_CNTR + ((v - i) * 3) - 9
 			if tmp2 > 10 and tmp2 < BOTTOM - 8 then
-				line(p, tmp2 + 8, p + 2, tmp2 + 8, SOLID, TEXT_COLOR)
+			   line(p, tmp2 + 8, p + 2, tmp2 + 8, SOLID, data.set_flags(0, data.TextColor))
 				if config[28].v == 0 and i % 10 == 0 and (i >= 0 or p > X_CNTR) and tmp2 < BOTTOM - 23 then
-					text(p + (p > X_CNTR and -1 or 4), tmp2, i, SMLSIZE + (p > X_CNTR and RIGHT or 0) + TEXT_COLOR)
+				   text(p + (p > X_CNTR and -1 or 4), tmp2, i, data.set_flags(SMLSIZE + (p > X_CNTR and RIGHT or 0),data.TextColor))
 				end
 			end
 		end
@@ -134,11 +134,10 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	end
 
 	-- Draw ground
-	color(CUSTOM_COLOR, GROUND)
 	if skip then
 		-- Must be going down hard!
 		if (pitch - 90) * (upsideDown and -1 or 1) < 0 then
-			fill(tl.x, tl.y, br.x - tl.x + 1, br.y - tl.y + 1, CUSTOM_COLOR)
+		   fill(tl.x, tl.y, br.x - tl.x + 1, br.y - tl.y + 1, data.set_flags(0, GROUND))
 		end
 	else
 		local trix, triy
@@ -155,21 +154,21 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		-- Find rectangle(s) and fill
 		if upsideDown then
 			if triy > tl.y then
-				fill(tl.x, tl.y, br.x - tl.x + 1, triy - tl.y, CUSTOM_COLOR)
+			   fill(tl.x, tl.y, br.x - tl.x + 1, triy - tl.y, data.set_flags(0, GROUND))
 			end
 			if roll > 90 and trix < br.x then
-				fill(trix, triy, br.x - trix + 1, br.y - triy + 1, CUSTOM_COLOR)
+				fill(trix, triy, br.x - trix + 1, br.y - triy + 1, data.set_flags(0, GROUND))
 			elseif roll <= 90 and trix > tl.x then
-				fill(tl.x, triy, trix - tl.x, br.y - triy + 1, CUSTOM_COLOR)
+				fill(tl.x, triy, trix - tl.x, br.y - triy + 1, data.set_flags(0, GROUND))
 			end
 		else
 			if triy < br.y then
-				fill(tl.x, triy + 1, br.x - tl.x + 1, br.y - triy, CUSTOM_COLOR)
+				fill(tl.x, triy + 1, br.x - tl.x + 1, br.y - triy, data.set_flags(0, GROUND))
 			end
 			if roll > 90 and trix > tl.x then
-				fill(tl.x, tl.y, trix - tl.x, triy - tl.y + 1, CUSTOM_COLOR)
+				fill(tl.x, tl.y, trix - tl.x, triy - tl.y + 1, data.set_flags(0, GROUND))
 			elseif roll <= 90 and trix < br.x then
-				fill(trix, tl.y, br.x - trix + 1, triy - tl.y + 1, CUSTOM_COLOR)
+				fill(trix, tl.y, br.x - trix + 1, triy - tl.y + 1, data.set_flags(0, GROUND))
 			end
 		end
 
@@ -197,14 +196,14 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			slope = abs(slope) * (tx1 < tx2 and 1 or -1)
 			for y = triy, top, steps do
 				if abs(steps) == 1 then
-					line(tx1, y, tx2, y, SOLID, CUSTOM_COLOR)
+				   line(tx1, y, tx2, y, SOLID, data.set_flags(0, GROUND))
 				else
 					if tx1 < tx2 then
 					--if tx1 < tx2 and tx2 - tx1 + 1 > 0 then
-						fill(tx1, y - s, tx2 - tx1 + 1, inc, CUSTOM_COLOR)
+						fill(tx1, y - s, tx2 - tx1 + 1, inc, data.set_flags(0, GROUND))
 					else
 					--elseif tx1 > tx2 and tx1 - tx2 + 1 > 0 then
-						fill(tx2, y - s, tx1 - tx2 + 1, inc, CUSTOM_COLOR)
+						fill(tx2, y - s, tx1 - tx2 + 1, inc, data.set_flags(0, GROUND))
 					end
 				end
 				tx1 = tx1 + slope
@@ -212,37 +211,39 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		end
 
 		-- Smooth horizon
+		local tmpcol = GROUND
 		if not upsideDown and inc <= 3 then
-			if inc > 1 then
-				if inc > 2 then
-					line(i[1].x, i[1].y + 2, i[2].x, i[2].y + 2, SOLID, CUSTOM_COLOR)
-				end
-				line(i[1].x, i[1].y + 1, i[2].x, i[2].y + 1, SOLID, CUSTOM_COLOR)
-				color(CUSTOM_COLOR, SKY)
-				line(i[1].x, i[1].y - 1, i[2].x, i[2].y - 1, SOLID, CUSTOM_COLOR)
-				if inc > 2 then
-					line(i[1].x, i[1].y - 2, i[2].x, i[2].y - 2, SOLID, CUSTOM_COLOR)
-				end
-				if 90 - roll > 25 then
-					line(i[1].x, i[1].y - 3, i[2].x, i[2].y - 3, SOLID, CUSTOM_COLOR)
-				end
-			end
-			color(CUSTOM_COLOR, LIGHTGREY)
-			line(i[1].x, i[1].y, i[2].x, i[2].y, SOLID, CUSTOM_COLOR)
+		   if inc > 1 then
+		      if inc > 2 then
+			 line(i[1].x, i[1].y + 2, i[2].x, i[2].y + 2, SOLID, data.set_flags(0, tmpcol))
+		      end
+		      line(i[1].x, i[1].y + 1, i[2].x, i[2].y + 1, SOLID, data.set_flags(0, tmpcol))
+		      tmpcol = SKY
+		      line(i[1].x, i[1].y - 1, i[2].x, i[2].y - 1, SOLID, data.set_flags(0, tmpcol))
+		      if inc > 2 then
+			 line(i[1].x, i[1].y - 2, i[2].x, i[2].y - 2, SOLID, data.set_flags(0, tmpcol))
+		      end
+		      if 90 - roll > 25 then
+			 line(i[1].x, i[1].y - 3, i[2].x, i[2].y - 3, SOLID, data.set_flags(0, tmpcol))
+		      end
+		   end
+		   tmpcol = LIGHTGREY
+		   line(i[1].x, i[1].y, i[2].x, i[2].y, SOLID, data.set_flags(0, tmpcol))
 		end
 	end
 
 	-- Pitch ladder
 	if data.telem then
-		tmp = pitch - 90
+	   tmp = pitch - 90
 		local tmp2 = max(min((tmp >= 0 and floor(tmp * 0.2) or math.ceil(tmp * 0.2)) * 5, 30), -30)
 		for x = tmp2 - 20, tmp2 + 20, 5 do
 			if x ~= 0 and (x % 10 == 0 or (x > -30 and x < 30)) then
 				pitchLadder(x % 10 == 0 and 20 or 15, x)
 			end
 		end
+
 		if not data.showMax then
-			text(X_CNTR - 65, Y_CNTR - 9, frmt("%.0f", upsideDown and -tmp or tmp) .. "\64", SMLSIZE + RIGHT)
+		   text(X_CNTR - 65, Y_CNTR - 9, frmt("%.0f", upsideDown and -tmp or tmp) .. "\64", data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 		end
 	end
 
@@ -250,22 +251,21 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	tics(data.speed, 1)
 	tics(data.altitude, RIGHT_POS - 4)
 	if config[28].v == 0 and config[33].v == 0 then
-		text(42, TOP - 1, units[data.speed_unit], SMLSIZE)
-		text(RIGHT_POS - 45, TOP - 1, "Alt " .. units[data.alt_unit], SMLSIZE + RIGHT)
+	   text(42, TOP - 1, units[data.speed_unit], data.set_flags(SMLSIZE, data.TextColor))
+	   text(RIGHT_POS - 45, TOP - 1, "Alt " .. units[data.alt_unit], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 	elseif config[28].v > 0 then
-		text(39, Y_CNTR - 25, units[data.speed_unit], SMLSIZE + RIGHT)
-		text(RIGHT_POS - 6, Y_CNTR - 25, "Alt " .. units[data.alt_unit], SMLSIZE + RIGHT)
+	   text(39, Y_CNTR - 25, units[data.speed_unit], data.set_flags(SMLSIZE + RIGHT,data.TextColor))
+	   text(RIGHT_POS - 6, Y_CNTR - 25, "Alt " .. units[data.alt_unit], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 	end
-
 	-- Compass
 	if data.showHead then
 		for i = 0, 348.75, 11.25 do
 			tmp = floor(((i - data.heading + (361 + HEADING_DEG * 0.5)) % 360) * PIXEL_DEG - 2.5)
 			if tmp >= 9 and tmp <= RIGHT_POS - 12 then
 				if i % 45 == 0 then
-					text(tmp, bot2, dir[i / 45], CENTERED + SMLSIZE)
+				   text(tmp, bot2, dir[i / 45], data.set_flags(CENTERED + SMLSIZE, data.TextColor))
 				else
-					line(tmp, BOTTOM - 4, tmp, BOTTOM - 1, SOLID, 0)
+				   line(tmp, BOTTOM - 4, tmp, BOTTOM - 1, SOLID, data.set_flags(0, data.TextColor))
 				end
 			end
 		end
@@ -276,7 +276,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 
 	-- Home direction
 	if data.showHead and data.armed and data.telem and data.gpsHome ~= false then
-		if data.distanceLast >= data.distRef then
+	   if data.distanceLast >= data.distRef then
 			local bearing = calcBearing(data.gpsHome, data.gpsLatLon) + 540 % 360
 			if config[15].v == 1 then
 				-- HUD method
@@ -326,16 +326,18 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 
 	-- Speed & altitude
 	tmp = data.showMax and data.speedMax or data.speed
-	text(39, Y_CNTR - 9, tmp >= 99.5 and floor(tmp + 0.5) or frmt("%.1f", tmp), SMLSIZE + RIGHT + data.telemFlags)
+	local telemCol = data.telem and data.TextColor or RED
+
+	text(39, Y_CNTR - 9, tmp >= 99.5 and floor(tmp + 0.5) or frmt("%.1f", tmp), data.set_flags(SMLSIZE + RIGHT, telemCol))
 	tmp = data.showMax and data.altitudeMax or data.altitude
-	text(RIGHT_POS - 2, Y_CNTR - 9, floor(tmp + 0.5), SMLSIZE + RIGHT + ((not data.telem or tmp + 0.5 >= config[6].v) and FLASH or 0))
+	text(RIGHT_POS - 2, Y_CNTR - 9, floor(tmp + 0.5), data.set_flags(SMLSIZE + RIGHT, ((not data.telem or tmp + 0.5 >= config[6].v) and RED or data.TextColor)))
 	if data.altHold then
 		bmap(icons.lock, RIGHT_POS - 55, Y_CNTR - 5)
 	end
 
 	-- Heading
 	if data.showHead then
-		text(X_CNTR + 18, bot2, floor(data.heading + 0.5) % 360 .. "\64", SMLSIZE + RIGHT + data.telemFlags)
+	   text(X_CNTR + 18, bot2, floor(data.heading + 0.5) % 360 .. "\64", data.set_flags(SMLSIZE + RIGHT, telemCol))
 	end
 
 	-- Roll scale
@@ -343,31 +345,26 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		bmap(icons.roll, 43, 20)
 		if roll > 30 and roll < 150 and not upsideDown then
 			local x1, y1, x2, y2, x3, y3 = calcDir(rad(roll - 90), rad(roll + 55), rad(roll - 235), X_CNTR - (cos(roll1) * 75), 79 - (sin(roll1) * 40), 7)
-			color(CUSTOM_COLOR, YELLOW)
-			line(x1, y1, x2, y2, SOLID, CUSTOM_COLOR)
-			line(x1, y1, x3, y3, SOLID, CUSTOM_COLOR)
-			line(x2, y2, x3, y3, SOLID, CUSTOM_COLOR)
+			line(x1, y1, x2, y2, SOLID, data.set_flags(0, YELLOW))
+			line(x1, y1, x3, y3, SOLID, data.set_flags(0, YELLOW))
+			line(x2, y2, x3, y3, SOLID, data.set_flags(0, YELLOW))
 		end
 	end
 
 	-- Variometer
 	if config[7].v % 2 == 1 then
-		color(CUSTOM_COLOR, DKGREY)
-		fill(RIGHT_POS, TOP, 10, BOTTOM - 20, CUSTOM_COLOR)
-		color(CUSTOM_COLOR, LIGHTGREY)
-		line(RIGHT_POS + 10, TOP, RIGHT_POS + 10, BOTTOM - 1, SOLID, CUSTOM_COLOR)
-		color(CUSTOM_COLOR, GREY)
-		line(RIGHT_POS, Y_CNTR - 1, RIGHT_POS + 9, Y_CNTR - 1, SOLID, CUSTOM_COLOR)
+		fill(RIGHT_POS, TOP, 10, BOTTOM - 20, data.set_flags(0, DKGREY))
+		line(RIGHT_POS + 10, TOP, RIGHT_POS + 10, BOTTOM - 1, SOLID, data.set_flags(0, LIGHTGREY))
+		line(RIGHT_POS, Y_CNTR - 1, RIGHT_POS + 9, Y_CNTR - 1, SOLID, data.set_flags(0, GREY))
 		if data.telem then
-			color(CUSTOM_COLOR, YELLOW)
-			tmp = math.log(1 + min(abs(0.6 * (data.vspeed_unit == 6 and data.vspeed * 0.3048 or data.vspeed)), 10)) * (data.vspeed < 0 and -1 or 1)
-			local y1 = Y_CNTR - (tmp * 0.416667 * (Y_CNTR - 21))
-			local y2 = Y_CNTR - (tmp * 0.384615 * (Y_CNTR - 21))
-			line(RIGHT_POS, y1 - 1, RIGHT_POS + 9, y2 - 1, SOLID, CUSTOM_COLOR)
-			line(RIGHT_POS, y1, RIGHT_POS + 9, y2, SOLID, CUSTOM_COLOR)
+		   tmp = math.log(1 + min(abs(0.6 * (data.vspeed_unit == 6 and data.vspeed * 0.3048 or data.vspeed)), 10)) * (data.vspeed < 0 and -1 or 1)
+		   local y1 = Y_CNTR - (tmp * 0.416667 * (Y_CNTR - 21))
+		   local y2 = Y_CNTR - (tmp * 0.384615 * (Y_CNTR - 21))
+		   line(RIGHT_POS, y1 - 1, RIGHT_POS + 9, y2 - 1, SOLID, data.set_flags(0, YELLOW))
+		   line(RIGHT_POS, y1, RIGHT_POS + 9, y2, SOLID, data.set_flags(0, YELLOW))
 		end
 		if data.startup == 0 then
-			text(RIGHT_POS + 13, TOP - 1, frmt(abs(data.vspeed) >= 9.95 and "%.0f" or "%.1f", data.vspeed) .. units[data.vspeed_unit], SMLSIZE + data.telemFlags)
+		   text(RIGHT_POS + 13, TOP - 1, frmt(abs(data.vspeed) >= 9.95 and "%.0f" or "%.1f", data.vspeed) .. units[data.vspeed_unit], data.set_flags(SMLSIZE, telemCol))
 		end
 	end
 
@@ -387,36 +384,36 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	if data.startup == 0 then
 		-- Launch/north-based orientation
 		if data.showDir or data.headingRef == -1 then
-			text(LEFT_POS + 2, Y_CNTR - 9, dir[6], SMLSIZE)
-			text(RIGHT_POS, Y_CNTR - 9, dir[2], SMLSIZE + RIGHT)
+		   text(LEFT_POS + 2, Y_CNTR - 9, dir[6], data.set_flags(SMLSIZE, data.TextColor))
+		   text(RIGHT_POS, Y_CNTR - 9, dir[2], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 		end
 		local cx, cy, d
 
 		-- Altitude graph
 		if config[28].v > 0 then
-			local factor = 30 / (data.altMax - data.altMin)
-			color(CUSTOM_COLOR, LIGHTMAP)
+		   local mcol = LIGHTMAP
+		   local factor = 30 / (data.altMax - data.altMin)
 			for i = 1, 60 do
 				cx = RIGHT_POS - 60 + i
 				cy = floor(BOTTOM - (data.alt[((data.altCur - 2 + i) % 60) + 1] - data.altMin) * factor + 0.5)
 				if cy < BOTTOM then
-					line(cx, cy, cx, BOTTOM - 1, SOLID, CUSTOM_COLOR)
+				   line(cx, cy, cx, BOTTOM - 1, SOLID, data.set_flags(0, mcol))
 				end
 				if (i - 1) % (60 / config[28].v) == 0 then
-					color(CUSTOM_COLOR, DKGREY)
-					line(cx, BOTTOM - 30, cx, BOTTOM - 1, DOTTED, CUSTOM_COLOR)
-					color(CUSTOM_COLOR, LIGHTMAP)
+				   mcol = DKGREY
+				   line(cx, BOTTOM - 30, cx, BOTTOM - 1, DOTTED, data.set_flags(0, mcol))
+				   mcol = LIGHTMAP
 				end
 			end
 			if data.altMin < -1 then
 				cy = BOTTOM - (-data.altMin * factor)
-				color(CUSTOM_COLOR, LIGHTGREY)
-				line(RIGHT_POS - 58, cy, RIGHT_POS - 1, cy, DOTTED, CUSTOM_COLOR)
+				mcol = LIGHTGREY
+				line(RIGHT_POS - 58, cy, RIGHT_POS - 1, cy, DOTTED, data.set_flags(0, mcol))
 				if cy < 142 then
-					text(RIGHT_POS - 59, cy - 8, "0", SMLSIZE + RIGHT)
+				   text(RIGHT_POS - 59, cy - 8, "0", data.set_flags(SMLSIZE + RIGHT,data.TextColor))
 				end
 			end
-			text(RIGHT_POS + 2, BOTTOM - 46, floor(data.altMax + 0.5) .. units[data.alt_unit], SMLSIZE + RIGHT)
+			text(RIGHT_POS + 2, BOTTOM - 46, floor(data.altMax + 0.5) .. units[data.alt_unit], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 		end
 
 		if data.gpsHome ~= false then
@@ -450,21 +447,19 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		end
 		-- Orientation
 		local x1, y1, x2, y2, x3, y3 = calcDir(r1, r2, r3, cx, cy, 8)
-		color(CUSTOM_COLOR, LIGHTGREY)
-		line(x2, y2, x3, y3, SOLID, CUSTOM_COLOR)
-		line(x1, y1, x2, y2, SOLID, TEXT_COLOR)
-		line(x1, y1, x3, y3, SOLID, TEXT_COLOR)
+		line(x2, y2, x3, y3, SOLID, data.set_flags(0, LIGHTGREY))
+		line(x1, y1, x2, y2, SOLID, data.set_flags(0, data.TextColor))
+		line(x1, y1, x3, y3, SOLID, data.set_flags(0, data.TextColor))
 		tmp = data.distanceLast < 1000 and floor(data.distanceLast + 0.5) .. units[data.dist_unit] or (frmt("%.1f", data.distanceLast / (data.dist_unit == 9 and 1000 or 5280)) .. (data.dist_unit == 9 and "km" or "mi"))
-		text(LEFT_POS + 2, BOTTOM - 16, tmp, SMLSIZE + data.telemFlags)
+		text(LEFT_POS + 2, BOTTOM - 16, tmp, data.set_flags(SMLSIZE, telemCol))
 	end
 
 	-- Startup message
 	if data.startup == 2 then
-		color(CUSTOM_COLOR, BLACK)
-		text(X_CNTR - 78, 55, "Lua Telemetry", MIDSIZE + CUSTOM_COLOR)
-		text(X_CNTR - 38, 85, "v" .. VERSION, MIDSIZE + CUSTOM_COLOR)
-		text(X_CNTR - 79, 54, "Lua Telemetry", MIDSIZE)
-		text(X_CNTR - 39, 84, "v" .. VERSION, MIDSIZE)
+		text(X_CNTR - 78, 55, "Lua Telemetry", data.set_flags(MIDSIZE, BLACK))
+		text(X_CNTR - 38, 85, "v" .. VERSION, data.set_flags(MIDSIZE, BLACK))
+		text(X_CNTR - 79, 54, "Lua Telemetry", data.set_flags(MIDSIZE, data.TextColor))
+		text(X_CNTR - 39, 84, "v" .. VERSION, data.set_flags(MIDSIZE, data.TextColor))
 	end
 
 	-- Data
@@ -475,130 +470,122 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	BOTTOM = 271
 
 	-- Box 1 (fuel, battery, rssi)
-	tmp = (not data.telem or data.cell < config[3].v or (data.showFuel and config[23].v == 0 and data.fuel <= config[17].v)) and FLASH or 0
+	tmp = (not data.telem or data.cell < config[3].v or (data.showFuel and config[23].v == 0 and data.fuel <= config[17].v)) and RED or data.TextColor
 	if data.showFuel then
 		if config[23].v > 0 or (data.crsf and data.showMax) then
-			text(X1, TOP + 1, (data.crsf and data.fuelRaw or data.fuel) .. data.fUnit[data.crsf and 1 or config[23].v], MIDSIZE + RIGHT + tmp)
+		   text(X1, TOP + 1, (data.crsf and data.fuelRaw or data.fuel) .. data.fUnit[data.crsf and 1 or config[23].v], data.set_flags(MIDSIZE + RIGHT, tmp))
 		else
-			text(X1 - 3, TOP, data.fuel .. "%", MIDSIZE + RIGHT + tmp)
+		   text(X1 - 3, TOP, data.fuel .. "%", data.set_flags(MIDSIZE + RIGHT, tmp))
 			if data.fl ~= data.fuel then
 				local red = data.fuel >= config[18].v and max(floor((100 - data.fuel) / (100 - config[18].v) * 255), 0) or 255
 				local green = data.fuel < config[18].v and max(floor((data.fuel - config[17].v) / (config[18].v - config[17].v) * 255), 0) or 255
 				data.fc = rgb(red, green, 60)
 				data.fl = data.fuel
 			end
-			color(CUSTOM_COLOR, data.fc)
-			lcd.drawGauge(0, TOP + 26, X1 - 3, 15, min(data.fuel, 99), 100, CUSTOM_COLOR)
+			lcd.drawGauge(0, TOP + 26, X1 - 3, 15, min(data.fuel, 99), 100, data.set_flags(0, data.fc))
 		end
-		text(0, TOP + ((config[23].v > 0 or (data.crsf and data.showMax)) and 23 or 9), labels[1], SMLSIZE)
+		text(0, TOP + ((config[23].v > 0 or (data.crsf and data.showMax)) and 23 or 9), labels[1], data.set_flags(SMLSIZE, data.TextColor))
 	end
 
 	local val = math.floor((data.showMax and data.cellMin or data.cell) * 100 + 0.5) * 0.01
-	text(X1 - 3, TOP + 42, frmt(config[1].v == 0 and "%.2fV" or "%.1fV", config[1].v == 0 and val or (data.showMax and data.battMin or data.batt)), MIDSIZE + RIGHT + tmp)
-	text(0, TOP + 51, labels[2], SMLSIZE)
+	text(X1 - 3, TOP + 42, frmt(config[1].v == 0 and "%.2fV" or "%.1fV", config[1].v == 0 and val or (data.showMax and data.battMin or data.batt)), data.set_flags(MIDSIZE + RIGHT,tmp))
+	text(0, TOP + 51, labels[2], data.set_flags(SMLSIZE, data.TextColor))
 	if data.bl ~= val then
 		local red = val >= config[2].v and max(floor((4.2 - val) / (4.2 - config[2].v) * 255), 0) or 255
 		local green = val < config[2].v and max(floor((val - config[3].v) / (config[2].v - config[3].v) * 255), 0) or 255
 		data.bc = rgb(red, green, 60)
 		data.bl = val
 	end
-	color(CUSTOM_COLOR, data.bc)
-	lcd.drawGauge(0, TOP + 68, X1 - 3, 15, min(max(val - config[3].v + 0.1, 0) * (100 / (4.2 - config[3].v + 0.1)), 99), 100, CUSTOM_COLOR)
+	lcd.drawGauge(0, TOP + 68, X1 - 3, 15, min(max(val - config[3].v + 0.1, 0) * (100 / (4.2 - config[3].v + 0.1)), 99), 100, data.set_flags(0,data.bc))
 
-	tmp = (not data.telem or data.rssi < data.rssiLow) and FLASH or 0
+	tmp = (not data.telem or data.rssi < data.rssiLow) and RED or data.TextColor
 	val = data.showMax and data.rssiMin or data.rssiLast
-	text(X1 - 3, TOP + 84, val .. (data.crsf and "%" or "dB"), MIDSIZE + RIGHT + tmp)
-	text(0, TOP + 93, data.crsf and "LQ" or "RSSI", SMLSIZE)
+	text(X1 - 3, TOP + 84, val .. (data.crsf and "%" or "dB"), data.set_flags(MIDSIZE + RIGHT,tmp))
+	text(0, TOP + 93, data.crsf and "LQ" or "RSSI", data.set_flags(SMLSIZE, data.TextColor))
 	if data.rl ~= val then
 		local red = val >= data.rssiLow and max(floor((100 - val) / (100 - data.rssiLow) * 255), 0) or 255
 		local green = val < data.rssiLow and max(floor((val - data.rssiCrit) / (data.rssiLow - data.rssiCrit) * 255), 0) or 255
 		data.rc = rgb(red, green, 60)
 		data.rl = val
 	end
-	color(CUSTOM_COLOR, data.rc)
-	lcd.drawGauge(0, TOP + 110, X1 - 3, 15, min(val, 99), 100, CUSTOM_COLOR)
+	lcd.drawGauge(0, TOP + 110, X1 - 3, 15, min(val, 99), 100, data.set_flags(0, data.rc))
 
 	-- Box 2 (altitude, distance, current)
 	tmp = data.showMax and data.altitudeMax or data.altitude
-	text(X1 + 9, TOP + 1, labels[4], SMLSIZE)
-	text(X2, TOP + 12, floor(tmp + 0.5) .. units[data.alt_unit], MIDSIZE + RIGHT + ((not data.telem or tmp + 0.5 >= config[6].v) and FLASH or 0))
+	text(X1 + 9, TOP + 1, labels[4], data.set_flags(SMLSIZE, data.TextColor))
+	text(X2, TOP + 12, floor(tmp + 0.5) .. units[data.alt_unit], data.set_flags(MIDSIZE + RIGHT,((not data.telem or tmp + 0.5 >= config[6].v) and RED or data.TextColor)))
 	tmp2 = data.showMax and data.distanceMax or data.distanceLast
 	tmp = tmp2 < 1000 and floor(tmp2 + 0.5) .. units[data.dist_unit] or (frmt("%.1f", tmp2 / (data.dist_unit == 9 and 1000 or 5280)) .. (data.dist_unit == 9 and "km" or "mi"))
-	text(X1 + 9, TOP + 44, labels[5], SMLSIZE)
-	text(X2, TOP + 55, tmp, MIDSIZE + RIGHT + data.telemFlags)
+	text(X1 + 9, TOP + 44, labels[5], data.set_flags(SMLSIZE, data.TextColor))
+	text(X2, TOP + 55, tmp, data.set_flags(MIDSIZE + RIGHT, telemCol))
 	if data.showCurr then
 		tmp = data.showMax and data.currentMax or data.current
-		text(X1 + 9, TOP + 87, labels[3], SMLSIZE)
-		text(X2, TOP + 98, (tmp >= 99.5 and floor(tmp + 0.5) or frmt("%.1fA", tmp)), MIDSIZE + RIGHT + data.telemFlags)
+		text(X1 + 9, TOP + 87, labels[3], data.set_flags(SMLSIZE, data.TextColor))
+		text(X2, TOP + 98, (tmp >= 99.5 and floor(tmp + 0.5) or frmt("%.1fA", tmp)), data.set_flags(MIDSIZE + RIGHT, telemCol))
 	end
 
 	-- Box 3 (flight modes, orientation)
 	tmp = (X2 + X3) * 0.5 + 4
-	text(tmp, TOP, modes[data.modeId].t, CENTERED + (modes[data.modeId].f == 3 and WARNING_COLOR or 0))
+	text(tmp, TOP, modes[data.modeId].t, data.set_flags(CENTERED, (modes[data.modeId].f == 3 and data.WarningColor or data.TextColor)))
 	if data.altHold then
 		bmap(icons.lock, X1 + 63, TOP + 4)
 	end
 	if data.headFree then
-		text(X2 + 7, TOP + 19, "HF", FLASH)
+	   text(X2 + 7, TOP + 19, "HF", data.set_flags(0, RED))
 	end
 
 	if data.showHead then
 		if data.showDir or data.headingRef == -1 then
-			text(tmp, TOP + 18, dir[0], CENTERED + SMLSIZE)
-			text(X3 - 4, 211, dir[2], SMLSIZE + RIGHT)
-			text(X2 + 10, 211, dir[6], SMLSIZE)
-			text(tmp + 4, BOTTOM - 15, floor(data.heading + 0.5) % 360 .. "\64", CENTERED + SMLSIZE + data.telemFlags)
+		   text(tmp, TOP + 18, dir[0], data.set_flags(CENTERED + SMLSIZE, data.TextColor))
+		   text(X3 - 4, 211, dir[2], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
+		   text(X2 + 10, 211, dir[6], data.set_flags(SMLSIZE, data.TextColor))
+			text(tmp + 4, BOTTOM - 15, floor(data.heading + 0.5) % 360 .. "\64", data.set_flags(CENTERED + SMLSIZE, telemCol))
 		end
 		local x1, y1, x2, y2, x3, y3 = calcDir(r1, r2, r3, tmp, 219, 25)
 		if data.headingHold then
-			fill((x2 + x3) * 0.5 - 2, (y2 + y3) * 0.5 - 2, 5, 5, SOLID)
+		   fill((x2 + x3) * 0.5 - 2, (y2 + y3) * 0.5 - 2, 5, 5, SOLID, data.set_flags(0,data.TextColor))
 		else
-			color(CUSTOM_COLOR, GREY)
-			line(x2, y2, x3, y3, SOLID, CUSTOM_COLOR)
+		   line(x2, y2, x3, y3, SOLID, data.set_flags(0, GREY))
 		end
-		line(x1, y1, x2, y2, SOLID, TEXT_COLOR)
-		line(x1, y1, x3, y3, SOLID, TEXT_COLOR)
+		line(x1, y1, x2, y2, SOLID, data.set_flags(0, data.TextColor))
+		line(x1, y1, x3, y3, SOLID, data.set_flags(0, data.TextColor))
 	end
 
 	-- Box 4 (GPS info, speed)
 	if data.crsf then
 		if data.tpwr then
-			text(RIGHT_POS, TOP, data.tpwr .. "mW", RIGHT + MIDSIZE + data.telemFlags)
+		   text(RIGHT_POS, TOP, data.tpwr .. "mW", data.set_flags(RIGHT + MIDSIZE, telemCol))
 		end
-		text(RIGHT_POS + 1, TOP + 28, data.satellites % 100, MIDSIZE + RIGHT + data.telemFlags)
+		text(RIGHT_POS + 1, TOP + 28, data.satellites % 100, data.set_flags(MIDSIZE + RIGHT, telemCol))
 	else
 		tmp = ((data.armed or data.modeId == 6) and data.hdop < 11 - config[21].v * 2) or not data.telem
-		text(X3 + 48, TOP, (data.hdop == 0 and not data.gpsFix) and "-- --" or (9 - data.hdop) * 0.5 + 0.8, MIDSIZE + RIGHT + (tmp and FLASH or 0))
-		text(X3 + 11, TOP + 24, "HDOP", SMLSIZE)
-		text(RIGHT_POS + 1, TOP, data.satellites % 100, MIDSIZE + RIGHT + data.telemFlags)
+		text(X3 + 48, TOP, (data.hdop == 0 and not data.gpsFix) and "-- --" or (9 - data.hdop) * 0.5 + 0.8, data.set_flags(MIDSIZE + RIGHT, (tmp and RED or data.TextColor)))
+		     text(X3 + 11, TOP + 24, "HDOP", data.set_flags(SMLSIZE, data.TextColor))
+		     text(RIGHT_POS + 1, TOP, data.satellites % 100, data.set_flags(MIDSIZE + RIGHT, telemCol))
 	end
 	hdopGraph(X3 + 65, TOP + (data.crsf and 51 or 23))
-	tmp = RIGHT + ((not data.telem or not data.gpsFix) and FLASH or 0)
+	tmp = ((not data.telem or not data.gpsFix) and RED or data.TextColor)
 	if not data.crsf then
-		text(RIGHT_POS, TOP + 28, floor(data.gpsAlt + 0.5) .. (data.gpsAlt_unit == 10 and "'" or units[data.gpsAlt_unit]), MIDSIZE + tmp)
+	   text(RIGHT_POS, TOP + 28, floor(data.gpsAlt + 0.5) .. (data.gpsAlt_unit == 10 and "'" or units[data.gpsAlt_unit]), data.set_flags(MIDSIZE+RIGHT, tmp))
 	end
-	text(RIGHT_POS, TOP + 54, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lat) or gpsDegMin(data.gpsLatLon.lat, true), tmp)
-	text(RIGHT_POS, TOP + 74, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lon) or gpsDegMin(data.gpsLatLon.lon, false), tmp)
+	text(RIGHT_POS, TOP + 54, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lat) or gpsDegMin(data.gpsLatLon.lat, true), data.set_flags(RIGHT, tmp))
+	text(RIGHT_POS, TOP + 74, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lon) or gpsDegMin(data.gpsLatLon.lon, false), data.set_flags(RIGHT, tmp))
 	tmp = data.showMax and data.speedMax or data.speed
-	text(RIGHT_POS + 1, TOP + 98, tmp >= 99.5 and floor(tmp + 0.5) .. units[data.speed_unit] or frmt("%.1f", tmp) .. units[data.speed_unit], MIDSIZE + RIGHT + data.telemFlags)
+	text(RIGHT_POS + 1, TOP + 98, tmp >= 99.5 and floor(tmp + 0.5) .. units[data.speed_unit] or frmt("%.1f", tmp) .. units[data.speed_unit], data.set_flags(MIDSIZE + RIGHT, telemCol))
 
 	-- Dividers
-	color(CUSTOM_COLOR, DKGREY)
-	line(X1 + 3, TOP, X1 + 3, BOTTOM, SOLID, CUSTOM_COLOR)
-	line(X2 + 3, TOP, X2 + 3, BOTTOM, SOLID, CUSTOM_COLOR)
-	line(X3 + 3, TOP, X3 + 3, BOTTOM, SOLID, CUSTOM_COLOR)
-	line(X3 + 3, TOP + 95, RIGHT_POS, TOP + 95, SOLID, CUSTOM_COLOR)
+	line(X1 + 3, TOP, X1 + 3, BOTTOM, SOLID, data.set_flags(0, DKGREY))
+	line(X2 + 3, TOP, X2 + 3, BOTTOM, SOLID, data.set_flags(0, DKGREY))
+	line(X3 + 3, TOP, X3 + 3, BOTTOM, SOLID, data.set_flags(0, DKGREY))
+	line(X3 + 3, TOP + 95, RIGHT_POS, TOP + 95, SOLID, data.set_flags(0, DKGREY))
 	if data.crsf then
-		line(X3 + 3, TOP + 28, RIGHT_POS, TOP + 28, SOLID, CUSTOM_COLOR)
+		line(X3 + 3, TOP + 28, RIGHT_POS, TOP + 28, SOLID, data.set_flags(0, DKGREY))
 	end
-	color(CUSTOM_COLOR, LIGHTGREY)
-	line(0, TOP - 1, LCD_W - 1, TOP - 1, SOLID, CUSTOM_COLOR)
+	line(0, TOP - 1, LCD_W - 1, TOP - 1, SOLID, data.set_flags(0, LIGHTGREY))
 
 	if data.showMax then
-		color(CUSTOM_COLOR, YELLOW)
-		fill(190, TOP - 20, 80, 20, CUSTOM_COLOR)
-		color(CUSTOM_COLOR, BLACK)
-		text(265, TOP - 20, "Min/Max", CUSTOM_COLOR + RIGHT)
+		fill(190, TOP - 20, 80, 20, data.set_flags(0, YELLOW))
+		text(265, TOP - 20, "Min/Max", data.set_flags(RIGHT, BLACK))
 	end
 end
 

--- a/src/SCRIPTS/TELEMETRY/iNav/horus.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/horus.lua
@@ -134,10 +134,11 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	end
 
 	-- Draw ground
+	local gflag = data.set_flags(0, GROUND)
 	if skip then
 		-- Must be going down hard!
 		if (pitch - 90) * (upsideDown and -1 or 1) < 0 then
-		   fill(tl.x, tl.y, br.x - tl.x + 1, br.y - tl.y + 1, data.set_flags(0, GROUND))
+		   fill(tl.x, tl.y, br.x - tl.x + 1, br.y - tl.y + 1, gflag)
 		end
 	else
 		local trix, triy
@@ -154,21 +155,21 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		-- Find rectangle(s) and fill
 		if upsideDown then
 			if triy > tl.y then
-			   fill(tl.x, tl.y, br.x - tl.x + 1, triy - tl.y, data.set_flags(0, GROUND))
+			   fill(tl.x, tl.y, br.x - tl.x + 1, triy - tl.y, gflag)
 			end
 			if roll > 90 and trix < br.x then
-				fill(trix, triy, br.x - trix + 1, br.y - triy + 1, data.set_flags(0, GROUND))
+				fill(trix, triy, br.x - trix + 1, br.y - triy + 1, gflag)
 			elseif roll <= 90 and trix > tl.x then
-				fill(tl.x, triy, trix - tl.x, br.y - triy + 1, data.set_flags(0, GROUND))
+				fill(tl.x, triy, trix - tl.x, br.y - triy + 1, gflag)
 			end
 		else
 			if triy < br.y then
-				fill(tl.x, triy + 1, br.x - tl.x + 1, br.y - triy, data.set_flags(0, GROUND))
+				fill(tl.x, triy + 1, br.x - tl.x + 1, br.y - triy, gflag)
 			end
 			if roll > 90 and trix > tl.x then
-				fill(tl.x, tl.y, trix - tl.x, triy - tl.y + 1, data.set_flags(0, GROUND))
+				fill(tl.x, tl.y, trix - tl.x, triy - tl.y + 1, gflag)
 			elseif roll <= 90 and trix < br.x then
-				fill(trix, tl.y, br.x - trix + 1, triy - tl.y + 1, data.set_flags(0, GROUND))
+				fill(trix, tl.y, br.x - trix + 1, triy - tl.y + 1, gflag)
 			end
 		end
 
@@ -196,14 +197,14 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			slope = abs(slope) * (tx1 < tx2 and 1 or -1)
 			for y = triy, top, steps do
 				if abs(steps) == 1 then
-				   line(tx1, y, tx2, y, SOLID, data.set_flags(0, GROUND))
+				   line(tx1, y, tx2, y, SOLID, gflag)
 				else
 					if tx1 < tx2 then
 					--if tx1 < tx2 and tx2 - tx1 + 1 > 0 then
-						fill(tx1, y - s, tx2 - tx1 + 1, inc, data.set_flags(0, GROUND))
+						fill(tx1, y - s, tx2 - tx1 + 1, inc, gflag)
 					else
 					--elseif tx1 > tx2 and tx1 - tx2 + 1 > 0 then
-						fill(tx2, y - s, tx1 - tx2 + 1, inc, data.set_flags(0, GROUND))
+						fill(tx2, y - s, tx1 - tx2 + 1, inc, gflag)
 					end
 				end
 				tx1 = tx1 + slope
@@ -211,24 +212,23 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		end
 
 		-- Smooth horizon
-		local tmpcol = GROUND
 		if not upsideDown and inc <= 3 then
 		   if inc > 1 then
 		      if inc > 2 then
-			 line(i[1].x, i[1].y + 2, i[2].x, i[2].y + 2, SOLID, data.set_flags(0, tmpcol))
+			 line(i[1].x, i[1].y + 2, i[2].x, i[2].y + 2, SOLID, gflag)
 		      end
-		      line(i[1].x, i[1].y + 1, i[2].x, i[2].y + 1, SOLID, data.set_flags(0, tmpcol))
+		      line(i[1].x, i[1].y + 1, i[2].x, i[2].y + 1, SOLID, gflag)
 		      tmpcol = SKY
-		      line(i[1].x, i[1].y - 1, i[2].x, i[2].y - 1, SOLID, data.set_flags(0, tmpcol))
+		      line(i[1].x, i[1].y - 1, i[2].x, i[2].y - 1, SOLID, gflag)
 		      if inc > 2 then
-			 line(i[1].x, i[1].y - 2, i[2].x, i[2].y - 2, SOLID, data.set_flags(0, tmpcol))
+			 line(i[1].x, i[1].y - 2, i[2].x, i[2].y - 2, SOLID, gflag)
 		      end
 		      if 90 - roll > 25 then
-			 line(i[1].x, i[1].y - 3, i[2].x, i[2].y - 3, SOLID, data.set_flags(0, tmpcol))
+			 line(i[1].x, i[1].y - 3, i[2].x, i[2].y - 3, SOLID, gflag)
 		      end
 		   end
-		   tmpcol = LIGHTGREY
-		   line(i[1].x, i[1].y, i[2].x, i[2].y, SOLID, data.set_flags(0, tmpcol))
+		   gflag = data.set_flags(0, LIGHTGREY)
+		   line(i[1].x, i[1].y, i[2].x, i[2].y, SOLID, gflag)
 		end
 	end
 
@@ -254,8 +254,9 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	   text(42, TOP - 1, units[data.speed_unit], data.set_flags(SMLSIZE, data.TextColor))
 	   text(RIGHT_POS - 45, TOP - 1, "Alt " .. units[data.alt_unit], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 	elseif config[28].v > 0 then
-	   text(39, Y_CNTR - 25, units[data.speed_unit], data.set_flags(SMLSIZE + RIGHT,data.TextColor))
-	   text(RIGHT_POS - 6, Y_CNTR - 25, "Alt " .. units[data.alt_unit], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
+	   local smrf = data.set_flags(SMLSIZE + RIGHT, data.TextColor)
+	   text(39, Y_CNTR - 25, units[data.speed_unit], smrf)
+	   text(RIGHT_POS - 6, Y_CNTR - 25, "Alt " .. units[data.alt_unit], smrf)
 	end
 	-- Compass
 	if data.showHead then
@@ -345,9 +346,10 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		bmap(icons.roll, 43, 20)
 		if roll > 30 and roll < 150 and not upsideDown then
 			local x1, y1, x2, y2, x3, y3 = calcDir(rad(roll - 90), rad(roll + 55), rad(roll - 235), X_CNTR - (cos(roll1) * 75), 79 - (sin(roll1) * 40), 7)
-			line(x1, y1, x2, y2, SOLID, data.set_flags(0, YELLOW))
-			line(x1, y1, x3, y3, SOLID, data.set_flags(0, YELLOW))
-			line(x2, y2, x3, y3, SOLID, data.set_flags(0, YELLOW))
+			local ycol = data.set_flags(0, YELLOW)
+			line(x1, y1, x2, y2, SOLID, ycol)
+			line(x1, y1, x3, y3, SOLID, ycol)
+			line(x2, y2, x3, y3, SOLID, ycol)
 		end
 	end
 
@@ -360,8 +362,9 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		   tmp = math.log(1 + min(abs(0.6 * (data.vspeed_unit == 6 and data.vspeed * 0.3048 or data.vspeed)), 10)) * (data.vspeed < 0 and -1 or 1)
 		   local y1 = Y_CNTR - (tmp * 0.416667 * (Y_CNTR - 21))
 		   local y2 = Y_CNTR - (tmp * 0.384615 * (Y_CNTR - 21))
-		   line(RIGHT_POS, y1 - 1, RIGHT_POS + 9, y2 - 1, SOLID, data.set_flags(0, YELLOW))
-		   line(RIGHT_POS, y1, RIGHT_POS + 9, y2, SOLID, data.set_flags(0, YELLOW))
+		   local ycol = data.set_flags(0, YELLOW)
+		   line(RIGHT_POS, y1 - 1, RIGHT_POS + 9, y2 - 1, SOLID, ycol)
+		   line(RIGHT_POS, y1, RIGHT_POS + 9, y2, SOLID, ycol)
 		end
 		if data.startup == 0 then
 		   text(RIGHT_POS + 13, TOP - 1, frmt(abs(data.vspeed) >= 9.95 and "%.0f" or "%.1f", data.vspeed) .. units[data.vspeed_unit], data.set_flags(SMLSIZE, telemCol))
@@ -391,24 +394,24 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 
 		-- Altitude graph
 		if config[28].v > 0 then
-		   local mcol = LIGHTMAP
+		   local mcol = data.set_flags(0,LIGHTMAP)
 		   local factor = 30 / (data.altMax - data.altMin)
 			for i = 1, 60 do
 				cx = RIGHT_POS - 60 + i
 				cy = floor(BOTTOM - (data.alt[((data.altCur - 2 + i) % 60) + 1] - data.altMin) * factor + 0.5)
 				if cy < BOTTOM then
-				   line(cx, cy, cx, BOTTOM - 1, SOLID, data.set_flags(0, mcol))
+				   line(cx, cy, cx, BOTTOM - 1, SOLID, mcol)
 				end
 				if (i - 1) % (60 / config[28].v) == 0 then
-				   mcol = DKGREY
-				   line(cx, BOTTOM - 30, cx, BOTTOM - 1, DOTTED, data.set_flags(0, mcol))
+				   mcol = data.set_flags(0, DKGREY)
+				   line(cx, BOTTOM - 30, cx, BOTTOM - 1, DOTTED, mcol)
 				   mcol = LIGHTMAP
 				end
 			end
 			if data.altMin < -1 then
 				cy = BOTTOM - (-data.altMin * factor)
-				mcol = LIGHTGREY
-				line(RIGHT_POS - 58, cy, RIGHT_POS - 1, cy, DOTTED, data.set_flags(0, mcol))
+				mcol =  data.set_flags(0,LIGHTMAP)
+				line(RIGHT_POS - 58, cy, RIGHT_POS - 1, cy, DOTTED, mcol)
 				if cy < 142 then
 				   text(RIGHT_POS - 59, cy - 8, "0", data.set_flags(SMLSIZE + RIGHT,data.TextColor))
 				end
@@ -435,7 +438,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 				--bmap(icons.home, hx - 4, hy - 5)
 				bmap(icons.home[1], hx - 8, hy - 10)
 			elseif d > 1 then
-				fill(hx - 1, hy - 1, 3, 3, SOLID)
+			   fill(hx - 1, hy - 1, 3, 3, SOLID, data.set_flags(0, data.TextColor))
 			end
 			-- Shift craft location
 			cx = d == 1 and X_CNTR + 2 or cx + hx
@@ -448,18 +451,21 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		-- Orientation
 		local x1, y1, x2, y2, x3, y3 = calcDir(r1, r2, r3, cx, cy, 8)
 		line(x2, y2, x3, y3, SOLID, data.set_flags(0, LIGHTGREY))
-		line(x1, y1, x2, y2, SOLID, data.set_flags(0, data.TextColor))
-		line(x1, y1, x3, y3, SOLID, data.set_flags(0, data.TextColor))
+		local tcol = data.set_flags(0, data.TextColor)
+		line(x1, y1, x2, y2, SOLID, tcol)
+		line(x1, y1, x3, y3, SOLID, tcol)
 		tmp = data.distanceLast < 1000 and floor(data.distanceLast + 0.5) .. units[data.dist_unit] or (frmt("%.1f", data.distanceLast / (data.dist_unit == 9 and 1000 or 5280)) .. (data.dist_unit == 9 and "km" or "mi"))
 		text(LEFT_POS + 2, BOTTOM - 16, tmp, data.set_flags(SMLSIZE, telemCol))
 	end
 
 	-- Startup message
 	if data.startup == 2 then
-		text(X_CNTR - 78, 55, "Lua Telemetry", data.set_flags(MIDSIZE, BLACK))
-		text(X_CNTR - 38, 85, "v" .. VERSION, data.set_flags(MIDSIZE, BLACK))
-		text(X_CNTR - 79, 54, "Lua Telemetry", data.set_flags(MIDSIZE, data.TextColor))
-		text(X_CNTR - 39, 84, "v" .. VERSION, data.set_flags(MIDSIZE, data.TextColor))
+	   local tcol = data.set_flags(MIDSIZE, BLACK)
+	   text(X_CNTR - 78, 55, "Lua Telemetry", tcol)
+	   text(X_CNTR - 38, 85, "v" .. VERSION, tcol)
+	   tcol = data.set_flags(MIDSIZE, data.TextColor)
+	   text(X_CNTR - 79, 54, "Lua Telemetry", tcol)
+	   text(X_CNTR - 39, 84, "v" .. VERSION, tcol)
 	end
 
 	-- Data
@@ -547,8 +553,9 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		else
 		   line(x2, y2, x3, y3, SOLID, data.set_flags(0, GREY))
 		end
-		line(x1, y1, x2, y2, SOLID, data.set_flags(0, data.TextColor))
-		line(x1, y1, x3, y3, SOLID, data.set_flags(0, data.TextColor))
+		local tcol = data.set_flags(0, data.TextColor)
+		line(x1, y1, x2, y2, SOLID, tcol)
+		line(x1, y1, x3, y3, SOLID, tcol)
 	end
 
 	-- Box 4 (GPS info, speed)
@@ -568,18 +575,20 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	if not data.crsf then
 	   text(RIGHT_POS, TOP + 28, floor(data.gpsAlt + 0.5) .. (data.gpsAlt_unit == 10 and "'" or units[data.gpsAlt_unit]), data.set_flags(MIDSIZE+RIGHT, tmp))
 	end
-	text(RIGHT_POS, TOP + 54, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lat) or gpsDegMin(data.gpsLatLon.lat, true), data.set_flags(RIGHT, tmp))
-	text(RIGHT_POS, TOP + 74, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lon) or gpsDegMin(data.gpsLatLon.lon, false), data.set_flags(RIGHT, tmp))
+	local pcol = data.set_flags(RIGHT, tmp)
+	text(RIGHT_POS, TOP + 54, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lat) or gpsDegMin(data.gpsLatLon.lat, true), pcol)
+	text(RIGHT_POS, TOP + 74, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lon) or gpsDegMin(data.gpsLatLon.lon, false), pcol)
 	tmp = data.showMax and data.speedMax or data.speed
 	text(RIGHT_POS + 1, TOP + 98, tmp >= 99.5 and floor(tmp + 0.5) .. units[data.speed_unit] or frmt("%.1f", tmp) .. units[data.speed_unit], data.set_flags(MIDSIZE + RIGHT, telemCol))
 
 	-- Dividers
-	line(X1 + 3, TOP, X1 + 3, BOTTOM, SOLID, data.set_flags(0, DKGREY))
-	line(X2 + 3, TOP, X2 + 3, BOTTOM, SOLID, data.set_flags(0, DKGREY))
-	line(X3 + 3, TOP, X3 + 3, BOTTOM, SOLID, data.set_flags(0, DKGREY))
-	line(X3 + 3, TOP + 95, RIGHT_POS, TOP + 95, SOLID, data.set_flags(0, DKGREY))
+	local dkgcol = data.set_flags(0, DKGREY)
+	line(X1 + 3, TOP, X1 + 3, BOTTOM, SOLID, dkgcol)
+	line(X2 + 3, TOP, X2 + 3, BOTTOM, SOLID, dkgcol)
+	line(X3 + 3, TOP, X3 + 3, BOTTOM, SOLID, dkgcol)
+	line(X3 + 3, TOP + 95, RIGHT_POS, TOP + 95, SOLID, dkgcol)
 	if data.crsf then
-		line(X3 + 3, TOP + 28, RIGHT_POS, TOP + 28, SOLID, data.set_flags(0, DKGREY))
+		line(X3 + 3, TOP + 28, RIGHT_POS, TOP + 28, SOLID, dkgcol)
 	end
 	line(0, TOP - 1, LCD_W - 1, TOP - 1, SOLID, data.set_flags(0, LIGHTGREY))
 

--- a/src/SCRIPTS/TELEMETRY/iNav/log.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/log.lua
@@ -153,7 +153,6 @@ local function playLog(data, config, distCalc, date, NEXT, PREV)
 				end
 			end
 			data.telem = true
-			data.telemFlags = 0
 		end
 	else
 		data.doLogs = false

--- a/src/SCRIPTS/TELEMETRY/iNav/menu.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/menu.lua
@@ -1,5 +1,4 @@
-local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId, getTelemetryUnit, SMLCD, FLASH, PREV, NEXT, HORUS, text, rect, fill, frmt, env)
-
+local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId, getTelemetryUnit, SMLCD, PREV, NEXT, HORUS, text, rect, fill, frmt, env)
 	local CONFIG_X = HORUS and (data.nv and 10 or 90) or (SMLCD and 0 or 46)
 	local TOP = HORUS and (data.nv and 107 or 37) or 11
 	local HIGH = HORUS and (data.nv and 28 or 22) or 9
@@ -52,13 +51,13 @@ local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId,
 		offOn = lang(config2)
 	end
 
+	local ccol = 0
 	if HORUS then
 		if not data.nv then
-			lcd.setColor(CUSTOM_COLOR, GREY)
-			fill(CONFIG_X - 10, TOP - 7, LCD_W - CONFIG_X * 2 + 20, HIGH * (ROWS + 1) + 12, CUSTOM_COLOR)
+		   fill(CONFIG_X - 10, TOP - 7, LCD_W - CONFIG_X * 2 + 20, HIGH * (ROWS + 1) + 12, data.set_flags(0, GREY))
 		end
-		rect(CONFIG_X - 10, TOP - 7, LCD_W - CONFIG_X * 2 + 20, HIGH * (ROWS + 1) + 12, TEXT_COLOR)
-		lcd.setColor(CUSTOM_COLOR, data.nv and LIGHTGREY or data.RGB(49, 48, 49)) -- Dark grey
+		rect(CONFIG_X - 10, TOP - 7, LCD_W - CONFIG_X * 2 + 20, HIGH * (ROWS + 1) + 12, data.set_flags(0, data.TextColor))
+		ccol = data.nv and LIGHTGREY or data.RGB(49, 48, 49) -- Dark grey
 	elseif not SMLCD then
 		rect(CONFIG_X - 5, TOP - 2, LCD_W - CONFIG_X * 2 + 10, HIGH * (ROWS + 1) + 1, SOLID)
 	end
@@ -185,14 +184,15 @@ local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId,
 	for i = data.configTop, bottom do
 		local y = (i - data.configTop) * HIGH + TOP
 		local z = config[i].z
-		local tmp = (data.configStatus == i and INVERS + data.configSelect or 0)
-		if config2[z].p == 1 and HORUS then
-			tmp = tmp + CUSTOM_COLOR
-		end
-		text(CONFIG_X, y, config2[z].t, FONT + ((config2[z].p == 1 and HORUS) and CUSTOM_COLOR or 0))
+		local tmp = (data.configStatus == i) and (INVERS + data.configSelect) or 0
+		local tmpf = 0
+		if HORUS then
+                   tmpf =  (config2[z].p == 1) and ccol or data.TextColor
+                end
+		text(CONFIG_X, y, config2[z].t, data.set_flags(FONT+tmp, tmpf))
 		if config2[z].p == nil then
 			if config2[z].l == nil then
-				text(CONFIG_X + RSIDE, y, (config[z].d ~= nil and frmt("%.1f", config[z].v) or config[z].v) .. config2[z].a, FONT + tmp)
+			   text(CONFIG_X + RSIDE, y, (config[z].d ~= nil and frmt("%.1f", config[z].v) or config[z].v) .. config2[z].a, data.set_flags(FONT + tmp, tmpf))
 			else
 				if config2[z].l == 0 then
 					if config[z].v == 0 then
@@ -204,14 +204,14 @@ local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId,
 					config2[z].l = offOn
 				end
 				if not config2[z].l then
-					text(CONFIG_X + RSIDE, y, config[z].v, FONT + tmp)
+				   text(CONFIG_X + RSIDE, y, config[z].v, data.set_flags(FONT + tmp, tmpf))
 				else
-					text(z == 16 and LCD_W - CONFIG_X or CONFIG_X + RSIDE, y, config2[z].l[config[z].v] .. ((config2[z].a == nil or config[z].v == 0) and "" or config2[z].a), FONT + tmp + (z == 16 and RIGHT or 0))
+				   text(z == 16 and LCD_W - CONFIG_X or CONFIG_X + RSIDE, y, config2[z].l[config[z].v] .. ((config2[z].a == nil or config[z].v == 0) and "" or config2[z].a), data.set_flags(FONT + tmp + (z == 16 and RIGHT or 0), tmpf))
 				end
 			end
 			config2[z] = nil
 		else
-			text(CONFIG_X + RSIDE, y, "--", FONT + tmp)
+		   text(CONFIG_X + RSIDE, y, "--", data.set_flags(FONT + tmp, tmpf))
 		end
 	end
 

--- a/src/SCRIPTS/TELEMETRY/iNav/nirvana.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/nirvana.lua
@@ -1,4 +1,4 @@
-local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGraph, icons, calcBearing, calcDir, VERSION, SMLCD, FLASH, FILE_PATH, text, line, rect, fill, frmt)
+local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGraph, icons, calcBearing, calcDir, VERSION, SMLCD, FILE_PATH, text, line, rect, fill, frmt)
 
 	local rgb = data.RGB
 	local SKY = rgb(50, 171, 230)
@@ -61,11 +61,11 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			local yd = cos(roll1) * r
 			local x1, y1, x2, y2 = x - xd, y + yd, x + xd, y - yd
 			if (y1 > top2 or y2 > top2) and (y1 < bot2 or y2 < bot2) and x1 >= 0 and x2 >= 0 then
-				color(CUSTOM_COLOR, r == 20 and WHITE or LIGHTGREY)
-				line(x1, y1, x2, y2, SOLID, CUSTOM_COLOR)
-				if r == 20 and y1 > top2 and y1 < bot2 then
-					text(x1, y1 - 8, upsideDown and -adj or adj, SMLSIZE + RIGHT)
-				end
+			   local rcol = (r == 20) and WHITE or LIGHTGREY
+			   line(x1, y1, x2, y2, SOLID, data.set_flags(0, rcol))
+			   if r == 20 and y1 > top2 and y1 < bot2 then
+			      text(x1, y1 - 8, upsideDown and -adj or adj, data.set_flags(SMLSIZE + RIGHT, data.TextColor))
+			   end
 			end
 		end
 	end
@@ -75,7 +75,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		for i = tmp - 40, tmp, 5 do
 			local tmp2 = Y_CNTR + ((v - i) * 3) - 9
 			if tmp2 > 10 and tmp2 < BOTTOM - 8 then
-				line(p, tmp2 + 8, p + 2, tmp2 + 8, SOLID, TEXT_COLOR)
+			   line(p, tmp2 + 8, p + 2, tmp2 + 8, SOLID, data.set_flags(0, data.TextColor))
 				--[[ Currently disabled due to preformance
 				if config[28].v == 0 and i % 10 == 0 and (i >= 0 or p > X_CNTR) and tmp2 < BOTTOM - 23 then
 					text(p + (p > X_CNTR and -1 or 4), tmp2, i, SMLSIZE + (p > X_CNTR and RIGHT or 0) + TEXT_COLOR)
@@ -136,11 +136,11 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	end
 
 	-- Draw ground
-	color(CUSTOM_COLOR, GROUND)
+	local gcol = GROUND
 	if skip then
 		-- Must be going down hard!
 		if (pitch - 90) * (upsideDown and -1 or 1) < 0 then
-			fill(tl.x, tl.y, br.x - tl.x + 1, br.y - tl.y + 1, CUSTOM_COLOR)
+		   fill(tl.x, tl.y, br.x - tl.x + 1, br.y - tl.y + 1, data.set_flags(0, gcol))
 		end
 	else
 		local trix, triy
@@ -157,21 +157,21 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		-- Find rectangle(s) and fill
 		if upsideDown then
 			if triy > tl.y then
-				fill(tl.x, tl.y, br.x - tl.x + 1, triy - tl.y, CUSTOM_COLOR)
+				fill(tl.x, tl.y, br.x - tl.x + 1, triy - tl.y, data.set_flags(0, gcol))
 			end
 			if roll > 90 and trix < br.x then
-				fill(trix, triy, br.x - trix + 1, br.y - triy + 1, CUSTOM_COLOR)
+				fill(trix, triy, br.x - trix + 1, br.y - triy + 1, data.set_flags(0, gcol))
 			elseif roll <= 90 and trix > tl.x then
-				fill(tl.x, triy, trix - tl.x, br.y - triy + 1, CUSTOM_COLOR)
+				fill(tl.x, triy, trix - tl.x, br.y - triy + 1, data.set_flags(0, gcol))
 			end
 		else
 			if triy < br.y then
-				fill(tl.x, triy + 1, br.x - tl.x + 1, br.y - triy, CUSTOM_COLOR)
+				fill(tl.x, triy + 1, br.x - tl.x + 1, br.y - triy, data.set_flags(0, gcol))
 			end
 			if roll > 90 and trix > tl.x then
-				fill(tl.x, tl.y, trix - tl.x, triy - tl.y + 1, CUSTOM_COLOR)
+				fill(tl.x, tl.y, trix - tl.x, triy - tl.y + 1, data.set_flags(0, gcol))
 			elseif roll <= 90 and trix < br.x then
-				fill(trix, tl.y, br.x - trix + 1, triy - tl.y + 1, CUSTOM_COLOR)
+				fill(trix, tl.y, br.x - trix + 1, triy - tl.y + 1, data.set_flags(0, gcol))
 			end
 		end
 
@@ -199,14 +199,14 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			slope = abs(slope) * (tx1 < tx2 and 1 or -1)
 			for y = triy, top, steps do
 				if abs(steps) == 1 then
-					line(tx1, y, tx2, y, SOLID, CUSTOM_COLOR)
+					line(tx1, y, tx2, y, SOLID, data.set_flags(0, gcol))
 				else
 					if tx1 < tx2 then
 					--if tx1 < tx2 and tx2 - tx1 + 1 > 0 then
-						fill(tx1, y - s, tx2 - tx1 + 1, inc, CUSTOM_COLOR)
+						fill(tx1, y - s, tx2 - tx1 + 1, inc, data.set_flags(0, gcol))
 					else
 					--elseif tx1 > tx2 and tx1 - tx2 + 1 > 0 then
-						fill(tx2, y - s, tx1 - tx2 + 1, inc, CUSTOM_COLOR)
+						fill(tx2, y - s, tx1 - tx2 + 1, inc, data.set_flags(0, gcol))
 					end
 				end
 				tx1 = tx1 + slope
@@ -217,20 +217,20 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		if not upsideDown and inc <= 3 then
 			if inc > 1 then
 				if inc > 2 then
-					line(i[1].x, i[1].y + 2, i[2].x, i[2].y + 2, SOLID, CUSTOM_COLOR)
+					line(i[1].x, i[1].y + 2, i[2].x, i[2].y + 2, SOLID, data.set_flags(0, gcol))
 				end
-				line(i[1].x, i[1].y + 1, i[2].x, i[2].y + 1, SOLID, CUSTOM_COLOR)
-				color(CUSTOM_COLOR, SKY)
-				line(i[1].x, i[1].y - 1, i[2].x, i[2].y - 1, SOLID, CUSTOM_COLOR)
+				line(i[1].x, i[1].y + 1, i[2].x, i[2].y + 1, SOLID, data.set_flags(0, gcol))
+				gcol = SKY
+				line(i[1].x, i[1].y - 1, i[2].x, i[2].y - 1, SOLID, data.set_flags(0, gcol))
 				if inc > 2 then
-					line(i[1].x, i[1].y - 2, i[2].x, i[2].y - 2, SOLID, CUSTOM_COLOR)
+					line(i[1].x, i[1].y - 2, i[2].x, i[2].y - 2, SOLID, data.set_flags(0, gcol))
 				end
 				if 90 - roll > 25 then
-					line(i[1].x, i[1].y - 3, i[2].x, i[2].y - 3, SOLID, CUSTOM_COLOR)
+					line(i[1].x, i[1].y - 3, i[2].x, i[2].y - 3, SOLID, data.set_flags(0, gcol))
 				end
 			end
-			color(CUSTOM_COLOR, LIGHTGREY)
-			line(i[1].x, i[1].y, i[2].x, i[2].y, SOLID, CUSTOM_COLOR)
+			gcol = LIGHTGREY
+			line(i[1].x, i[1].y, i[2].x, i[2].y, SOLID, data.set_flags(0, gcol))
 		end
 	end
 
@@ -244,7 +244,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			end
 		end
 		if not data.showMax then
-			text(X_CNTR - 60, Y_CNTR - 10, frmt("%.0f", upsideDown and -tmp or tmp) .. "\64", SMLSIZE + RIGHT)
+		   text(X_CNTR - 60, Y_CNTR - 10, frmt("%.0f", upsideDown and -tmp or tmp) .. "\64", data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 		end
 	end
 
@@ -252,8 +252,8 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	if config[28].v == 0 then
 		tics(data.speed, 1)
 		tics(data.altitude, RIGHT_POS - 4)
-		text(42, Y_CNTR - 25, units[data.speed_unit], SMLSIZE + RIGHT)
-		text(RIGHT_POS - 4, Y_CNTR - 25, "Alt " .. units[data.alt_unit], SMLSIZE + RIGHT)
+		text(42, Y_CNTR - 25, units[data.speed_unit], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
+		text(RIGHT_POS - 4, Y_CNTR - 25, "Alt " .. units[data.alt_unit], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 	end
 
 	-- Compass
@@ -262,7 +262,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			tmp = floor(((i - data.heading + (361 + HEADING_DEG * 0.5)) % 360) * PIXEL_DEG - 2.5)
 			if tmp >= 9 and tmp <= RIGHT_POS - 12 then
 				if i % 45 == 0 then
-					text(tmp, bot2, dir[i / 45], CENTERED + SMLSIZE)
+				   text(tmp, bot2, dir[i / 45], data.set_flags(CENTERED + SMLSIZE, data.TextColor))
 				else
 					line(tmp, BOTTOM - 4, tmp, BOTTOM - 1, SOLID, 0)
 				end
@@ -323,21 +323,20 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	-- View overlay
 	bmap(icons.fg, 1, 20)
 	--line(0, BOTTOM, RIGHT_POS, BOTTOM, SOLID, DKGREY)
-	color(CUSTOM_COLOR, MAP)
-	line(0, BOTTOM + 1, RIGHT_POS, BOTTOM + 1, SOLID, CUSTOM_COLOR)
-
+	line(0, BOTTOM + 1, RIGHT_POS, BOTTOM + 1, SOLID, data.set_flags(0, MAP))
+	local telemCol = (data.telem) and data.TextColor or RED
 	-- Speed & altitude
 	tmp = data.showMax and data.speedMax or data.speed
-	text(41, Y_CNTR - 9, tmp >= 99.5 and floor(tmp + 0.5) or frmt("%.1f", tmp), SMLSIZE + RIGHT + data.telemFlags)
+	text(41, Y_CNTR - 9, tmp >= 99.5 and floor(tmp + 0.5) or frmt("%.1f", tmp), data.set_flags(SMLSIZE + RIGHT, telemCol))
 	tmp = data.showMax and data.altitudeMax or data.altitude
-	text(RIGHT_POS, Y_CNTR - 9, floor(tmp + 0.5), SMLSIZE + RIGHT + ((not data.telem or tmp + 0.5 >= config[6].v) and FLASH or 0))
+	text(RIGHT_POS, Y_CNTR - 9, floor(tmp + 0.5), data.set_flags(SMLSIZE + RIGHT, ((not data.telem or tmp + 0.5 >= config[6].v) and RED or data.TextColor)))
 	if data.altHold then
 		bmap(icons.lock, RIGHT_POS - 55, Y_CNTR - 5)
 	end
 
 	-- Heading
 	if data.showHead then
-		text(X_CNTR + 20, bot2, floor(data.heading + 0.5) % 360 .. "\64", SMLSIZE + RIGHT + data.telemFlags)
+	   text(X_CNTR + 20, bot2, floor(data.heading + 0.5) % 360 .. "\64", data.set_flags(SMLSIZE + RIGHT, telemCol))
 	end
 
 	-- Roll scale
@@ -345,50 +344,48 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		bmap(icons.roll, 43, 20)
 		if roll > 30 and roll < 150 and not upsideDown then
 			local x1, y1, x2, y2, x3, y3 = calcDir(rad(roll - 90), rad(roll + 55), rad(roll - 235), X_CNTR - (cos(roll1) * 75), 79 - (sin(roll1) * 40), 7)
-			color(CUSTOM_COLOR, YELLOW)
-			line(x1, y1, x2, y2, SOLID, CUSTOM_COLOR)
-			line(x1, y1, x3, y3, SOLID, CUSTOM_COLOR)
-			line(x2, y2, x3, y3, SOLID, CUSTOM_COLOR)
+			line(x1, y1, x2, y2, SOLID, data.set_flags(0, YELLOW))
+			line(x1, y1, x3, y3, SOLID, data.set_flags(0, YELLOW))
+			line(x2, y2, x3, y3, SOLID, data.set_flags(0, YELLOW))
 		end
 	end
 
 	--[[ Variometer
 	if config[7].v % 2 == 1 then
-		color(CUSTOM_COLOR, DKGREY)
-		fill(RIGHT_POS, TOP, 10, BOTTOM - 20, CUSTOM_COLOR)
-		color(CUSTOM_COLOR, LIGHTGREY)
-		line(RIGHT_POS + 10, TOP, RIGHT_POS + 10, BOTTOM - 1, SOLID, CUSTOM_COLOR)
-		color(CUSTOM_COLOR, GREY)
-		line(RIGHT_POS, Y_CNTR - 1, RIGHT_POS + 9, Y_CNTR - 1, SOLID, CUSTOM_COLOR)
+		color(CUSTOM__COLOR, DKGREY)
+		fill(RIGHT_POS, TOP, 10, BOTTOM - 20, CUSTOM__COLOR)
+		color(CUSTOM__COLOR, LIGHTGREY)
+		line(RIGHT_POS + 10, TOP, RIGHT_POS + 10, BOTTOM - 1, SOLID, CUSTOM__COLOR)
+		color(CUSTOM__COLOR, GREY)
+		line(RIGHT_POS, Y_CNTR - 1, RIGHT_POS + 9, Y_CNTR - 1, SOLID, CUSTOM__COLOR)
 		if data.telem then
-			color(CUSTOM_COLOR, YELLOW)
+			color(CUSTOM__COLOR, YELLOW)
 			tmp = math.log(1 + min(abs(0.6 * (data.vspeed_unit == 6 and data.vspeed * 0.3048 or data.vspeed)), 10)) * (data.vspeed < 0 and -1 or 1)
 			local y1 = Y_CNTR - (tmp * 0.416667 * (Y_CNTR - 21))
 			local y2 = Y_CNTR - (tmp * 0.384615 * (Y_CNTR - 21))
-			line(RIGHT_POS, y1 - 1, RIGHT_POS + 9, y2 - 1, SOLID, CUSTOM_COLOR)
-			line(RIGHT_POS, y1, RIGHT_POS + 9, y2, SOLID, CUSTOM_COLOR)
+			line(RIGHT_POS, y1 - 1, RIGHT_POS + 9, y2 - 1, SOLID, CUSTOM__COLOR)
+			line(RIGHT_POS, y1, RIGHT_POS + 9, y2, SOLID, CUSTOM__COLOR)
 		end
 		if data.startup == 0 then
-			text(RIGHT_POS + 13, TOP - 1, frmt(abs(data.vspeed) >= 9.95 and "%.0f" or "%.1f", data.vspeed) .. units[data.vspeed_unit], SMLSIZE + data.telemFlags)
+			text(RIGHT_POS + 13, TOP - 1, frmt(abs(data.vspeed) >= 9.95 and "%.0f" or "%.1f", data.vspeed) .. units[data.vspeed_unit], SMLSIZE + data.telem__Flags)
 		end
 	end
 	]]
 
 	-- RSSI/LQ
-	tmp = (not data.telem or data.rssi < data.rssiLow) and FLASH or 0
+	tmp = (not data.telem or data.rssi < data.rssiLow) and RED or data.TextColor
 	local val = data.showMax and data.rssiMin or data.rssiLast
-	text(LCD_W + 1, BOTTOM - 19, val .. (data.crsf and "%" or "dB"), RIGHT + tmp)
-	text(LCD_W - 43, TOP, data.crsf and "  LQ" or "RSSI", SMLSIZE)
+	text(LCD_W + 1, BOTTOM - 19, val .. (data.crsf and "%" or "dB"), data.set_flags(RIGHT, tmp))
+	text(LCD_W - 43, TOP, data.crsf and "  LQ" or "RSSI", data.set_flags(SMLSIZE, data.TextColor))
 	if data.rl ~= val then
 		local red = val >= data.rssiLow and max(floor((100 - val) / (100 - data.rssiLow) * 255), 0) or 255
 		local green = val < data.rssiLow and max(floor((val - data.rssiCrit) / (data.rssiLow - data.rssiCrit) * 255), 0) or 255
 		data.rc = rgb(red, green, 60)
 		data.rl = val
 	end
-	color(CUSTOM_COLOR, data.rc)
-	rect(LCD_W - 32, TOP + 20, 15, 88, CUSTOM_COLOR)
+	rect(LCD_W - 32, TOP + 20, 15, 88, data.set_flags(0, data.rc))
 	local h = math.floor(max(1, (min(val, 100) * 0.01) * 86))
-	fill(LCD_W - 31, TOP + 107 - h, 13, h, CUSTOM_COLOR)
+	fill(LCD_W - 31, TOP + 107 - h, 13, h, data.set_flags(0, data.rc))
 
 	-- Calc orientation
 	tmp = data.headingRef
@@ -408,36 +405,36 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	if data.startup == 0 then
 		-- Launch/north-based orientation
 		if data.showDir or data.headingRef == -1 then
-			text(LEFT_POS + 2, Y_CNTR - 9, dir[6], SMLSIZE)
-			text(RIGHT_POS, Y_CNTR - 9, dir[2], SMLSIZE + RIGHT)
+		   text(LEFT_POS + 2, Y_CNTR - 9, dir[6], data.set_flags(SMLSIZE, data.TextColor))
+		   text(RIGHT_POS, Y_CNTR - 9, dir[2], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 		end
 		local cx, cy, d
 
 		-- Altitude graph
 		if config[28].v > 0 then
 			local factor = 30 / (data.altMax - data.altMin)
-			color(CUSTOM_COLOR, LIGHTMAP)
+			local mcol = LIGHTMAP
 			for i = 1, 60 do
 				cx = RIGHT_POS - 60 + i
 				cy = floor(BOTTOM - (data.alt[((data.altCur - 2 + i) % 60) + 1] - data.altMin) * factor + 0.5)
 				if cy < BOTTOM then
-					line(cx, cy, cx, BOTTOM - 1, SOLID, CUSTOM_COLOR)
+				   line(cx, cy, cx, BOTTOM - 1, SOLID, data.set_flags(0, mcol))
 				end
 				if (i - 1) % (60 / config[28].v) == 0 then
-					color(CUSTOM_COLOR, BLACK)
-					line(cx, BOTTOM - 30, cx, BOTTOM - 1, DOTTED, CUSTOM_COLOR)
-					color(CUSTOM_COLOR, LIGHTMAP)
+				   mcol = BLACK
+				   line(cx, BOTTOM - 30, cx, BOTTOM - 1, DOTTED, data.set_flags(0, mcol))
+				   mcol = LIGHTMAP
 				end
 			end
 			if data.altMin < -1 then
 				cy = BOTTOM - (-data.altMin * factor)
-				color(CUSTOM_COLOR, BLACK)
-				line(RIGHT_POS - 58, cy, RIGHT_POS - 1, cy, DOTTED, CUSTOM_COLOR)
+				mcol = BLACK
+				line(RIGHT_POS - 58, cy, RIGHT_POS - 1, cy, DOTTED, data.set_flags(0, mcol))
 				if cy < 142 then
-					text(RIGHT_POS - 59, cy - 8, "0", SMLSIZE + RIGHT)
+				   text(RIGHT_POS - 59, cy - 8, "0", data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 				end
 			end
-			text(RIGHT_POS + 2, BOTTOM - 46, floor(data.altMax + 0.5) .. units[data.alt_unit], SMLSIZE + RIGHT)
+			text(RIGHT_POS + 2, BOTTOM - 46, floor(data.altMax + 0.5) .. units[data.alt_unit], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 		end
 
 		if data.gpsHome ~= false then
@@ -471,21 +468,19 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		end
 		-- Orientation
 		local x1, y1, x2, y2, x3, y3 = calcDir(r1, r2, r3, cx, cy, 8)
-		color(CUSTOM_COLOR, LIGHTGREY)
-		line(x2, y2, x3, y3, SOLID, CUSTOM_COLOR)
-		line(x1, y1, x2, y2, SOLID, TEXT_COLOR)
-		line(x1, y1, x3, y3, SOLID, TEXT_COLOR)
+		line(x2, y2, x3, y3, SOLID, data.set_flags(0, LIGHTGREY))
+		line(x1, y1, x2, y2, SOLID, data.set_flags(0, data.TextColor))
+		line(x1, y1, x3, y3, SOLID, data.set_flags(0, data.TextColor))
 		tmp = data.distanceLast < 1000 and floor(data.distanceLast + 0.5) .. units[data.dist_unit] or (frmt("%.1f", data.distanceLast / (data.dist_unit == 9 and 1000 or 5280)) .. (data.dist_unit == 9 and "km" or "mi"))
-		text(LEFT_POS + 2, BOTTOM - 16, tmp, SMLSIZE + data.telemFlags)
+		text(LEFT_POS + 2, BOTTOM - 16, tmp, data.set_flags(SMLSIZE, telemCol))
 	end
 
 	-- Startup message
 	if data.startup == 2 then
-		color(CUSTOM_COLOR, BLACK)
-		text(X_CNTR - 78, 192, "Lua Telemetry", MIDSIZE + CUSTOM_COLOR)
-		text(X_CNTR - 38, 222, "v" .. VERSION, MIDSIZE + CUSTOM_COLOR)
-		text(X_CNTR - 79, 191, "Lua Telemetry", MIDSIZE)
-		text(X_CNTR - 39, 221, "v" .. VERSION, MIDSIZE)
+	   text(X_CNTR - 78, 192, "Lua Telemetry", data.set_flags(MIDSIZE, BLACK))
+	   text(X_CNTR - 38, 222, "v" .. VERSION, data.set_flags(MIDSIZE, BLACK))
+	   text(X_CNTR - 79, 191, "Lua Telemetry", data.set_flags(MIDSIZE, data.TextColor))
+	   text(X_CNTR - 39, 221, "v" .. VERSION, data.set_flags(MIDSIZE, data.TextColor))
 	end
 
 	-- Data
@@ -496,14 +491,14 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	BOTTOM = 479
 
 	-- Box 1 (fuel, battery)
-	tmp = (not data.telem or data.cell < config[3].v or (data.showFuel and config[23].v == 0 and data.fuel <= config[17].v)) and FLASH or 0
+	tmp = (not data.telem or data.cell < config[3].v or (data.showFuel and config[23].v == 0 and data.fuel <= config[17].v)) and RED or data.TextColor
 	local btop = TOP - 54
 	local bleft = 0
 	local bwidth = 150
 	local bright = 150
 	if data.showFuel then
 		if config[23].v > 0 or (data.crsf and data.showMax) then
-			text(bright, btop, (data.crsf and data.fuelRaw or data.fuel) .. data.fUnit[data.crsf and 1 or config[23].v], MIDSIZE + RIGHT + tmp)
+		   text(bright, btop, (data.crsf and data.fuelRaw or data.fuel) .. data.fUnit[data.crsf and 1 or config[23].v], data.set_flags(MIDSIZE + RIGHT, tmp))
 		else
 			text(bright, btop, data.fuel .. "%", MIDSIZE + RIGHT + tmp)
 			if data.fl ~= data.fuel then
@@ -512,111 +507,105 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 				data.fc = rgb(red, green, 60)
 				data.fl = data.fuel
 			end
-			color(CUSTOM_COLOR, data.fc)
-			--lcd.drawGauge(bleft, btop + 26, bwidth, 15, min(data.fuel, 99), 100, CUSTOM_COLOR)
-			rect(bleft, btop + 27, bwidth, 15, CUSTOM_COLOR)
+			--lcd.drawGauge(bleft, btop + 26, bwidth, 15, min(data.fuel, 99), 100, CUSTOM__COLOR)
+			rect(bleft, btop + 27, bwidth, 15, data.set_flags(0, data.fc))
 			local w = max(1, (min(data.fuel, 100) * 0.01) * (bwidth - 2))
-			fill(1, btop + 28, w, 13, CUSTOM_COLOR)
+			fill(1, btop + 28, w, 13, data.set_flags(0, data.fc))
 		end
-		text(bleft, btop + ((config[23].v > 0 or (data.crsf and data.showMax)) and 23 or 9), labels[1], SMLSIZE)
+		text(bleft, btop + ((config[23].v > 0 or (data.crsf and data.showMax)) and 23 or 9), labels[1], data.set_flags(SMLSIZE, data.TextColor))
 	end
 
 	bleft = 170
 	bright = LCD_W - 1
 	val = math.floor((data.showMax and data.cellMin or data.cell) * 100 + 0.5) * 0.01
-	text(bright, btop, frmt(config[1].v == 0 and "%.2fV" or "%.1fV", config[1].v == 0 and val or (data.showMax and data.battMin or data.batt)), MIDSIZE + RIGHT + tmp)
-	text(bleft, btop + 9, labels[2], SMLSIZE)
+	text(bright, btop, frmt(config[1].v == 0 and "%.2fV" or "%.1fV", config[1].v == 0 and val or (data.showMax and data.battMin or data.batt)), data.set_flags(MIDSIZE + RIGHT, tmp))
+	text(bleft, btop + 9, labels[2], data.set_flags(SMLSIZE, data.TextColor))
 	if data.bl ~= val then
 		local red = val >= config[2].v and max(floor((4.2 - val) / (4.2 - config[2].v) * 255), 0) or 255
 		local green = val < config[2].v and max(floor((val - config[3].v) / (config[2].v - config[3].v) * 255), 0) or 255
 		data.bc = rgb(red, green, 60)
 		data.bl = val
 	end
-	color(CUSTOM_COLOR, data.bc)
-	--lcd.drawGauge(bleft,  btop + 27, bwidth, 15, min(max(val - config[3].v + 0.1, 0) * (100 / (4.2 - config[3].v + 0.1)), 99), 100, CUSTOM_COLOR)
-	rect(bleft, btop + 27, bwidth, 15, CUSTOM_COLOR)
+	--lcd.drawGauge(bleft,  btop + 27, bwidth, 15, min(max(val - config[3].v + 0.1, 0) * (100 / (4.2 - config[3].v + 0.1)), 99), 100, CUSTOM__COLOR)
+	rect(bleft, btop + 27, bwidth, 15, data.set_flags(0, data.bc))
 	local w = max(1, (min(max(val - config[3].v + 0.1, 0) * (100 / (4.2 - config[3].v + 0.1)), 100) * 0.01) * (bwidth - 2))
-	fill(bleft + 1, btop + 28, w, 13, CUSTOM_COLOR)
+	fill(bleft + 1, btop + 28, w, 13, data.set_flags(0, data.bc))
 
 	-- Box 2 (altitude, distance, current)
 	tmp = data.showMax and data.altitudeMax or data.altitude
-	text(X1 + 9, TOP + 1, labels[4], SMLSIZE)
-	text(X2, TOP + 12, floor(tmp + 0.5) .. units[data.alt_unit], MIDSIZE + RIGHT + ((not data.telem or tmp + 0.5 >= config[6].v) and FLASH or 0))
+	text(X1 + 9, TOP + 1, labels[4], data.set_flags(SMLSIZE,data.TextColor))
+	text(X2, TOP + 12, floor(tmp + 0.5) .. units[data.alt_unit], data.set_flags(MIDSIZE + RIGHT, ((not data.telem or tmp + 0.5 >= config[6].v) and RED or data.TextColor)))
 	tmp2 = data.showMax and data.distanceMax or data.distanceLast
 	tmp = tmp2 < 1000 and floor(tmp2 + 0.5) .. units[data.dist_unit] or (frmt("%.1f", tmp2 / (data.dist_unit == 9 and 1000 or 5280)) .. (data.dist_unit == 9 and "km" or "mi"))
-	text(X1 + 9, TOP + 44, labels[5], SMLSIZE)
-	text(X2, TOP + 55, tmp, MIDSIZE + RIGHT + data.telemFlags)
+	text(X1 + 9, TOP + 44, labels[5], data.set_flags(SMLSIZE, data.TextColor))
+	text(X2, TOP + 55, tmp, data.set_flags(MIDSIZE + RIGHT, telemCol))
 	if data.showCurr then
 		tmp = data.showMax and data.currentMax or data.current
 		text(X1 + 9, TOP + 87, labels[3], SMLSIZE)
-		text(X2, TOP + 98, (tmp >= 99.5 and floor(tmp + 0.5) or frmt("%.1fA", tmp)), MIDSIZE + RIGHT + data.telemFlags)
+		text(X2, TOP + 98, (tmp >= 99.5 and floor(tmp + 0.5) or frmt("%.1fA", tmp)), data.set_flags(MIDSIZE + RIGHT, telemCol))
 	end
 
 	-- Box 3 (flight modes, orientation)
 	tmp = (X2 + X3) * 0.5 + 4
-	text(tmp, TOP, modes[data.modeId].t, CENTERED + (modes[data.modeId].f == 3 and WARNING_COLOR or 0))
+	text(tmp, TOP, modes[data.modeId].t, data.set_flags(CENTERED,  (modes[data.modeId].f == 3 and data.WarningColor or data.TextColor)))
 	if data.altHold then
 		bmap(icons.lock, X1 + 63, TOP + 4)
 	end
 	if data.headFree then
-		text(X2 + 7, TOP + 19, "HF", FLASH)
+	   text(X2 + 7, TOP + 19, "HF", data.set_flags(0, RED))
 	end
 
 	if data.showHead then
 		if data.showDir or data.headingRef == -1 then
-			text(tmp, TOP + 18, dir[0], CENTERED + SMLSIZE)
-			text(X3 - 4, 421, dir[2], SMLSIZE + RIGHT)
-			text(X2 + 10, 421, dir[6], SMLSIZE)
-			text(tmp + 4, BOTTOM - 15, floor(data.heading + 0.5) % 360 .. "\64", CENTERED + SMLSIZE + data.telemFlags)
+		   text(tmp, TOP + 18, dir[0], data.set_flags(CENTERED + SMLSIZE, data.TextColor))
+		   text(X3 - 4, 421, dir[2], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
+		   text(X2 + 10, 421, dir[6], data.set_flags(SMLSIZE, data.TextColor))
+		   text(tmp + 4, BOTTOM - 15, floor(data.heading + 0.5) % 360 .. "\64", data.set_flags(CENTERED + SMLSIZE, telemCol))
 		end
 		local x1, y1, x2, y2, x3, y3 = calcDir(r1, r2, r3, tmp, 429, 25)
 		if data.headingHold then
-			fill((x2 + x3) * 0.5 - 2, (y2 + y3) * 0.5 - 2, 5, 5, SOLID)
+			fill((x2 + x3) * 0.5 - 2, (y2 + y3) * 0.5 - 2, 5, 5, SOLID, data.set_flags(0, data.TextColor))
 		else
-			color(CUSTOM_COLOR, DKGREY)
-			line(x2, y2, x3, y3, SOLID, CUSTOM_COLOR)
+			line(x2, y2, x3, y3, SOLID, data.set_flags(0, DKGREY))
 		end
-		line(x1, y1, x2, y2, SOLID, TEXT_COLOR)
-		line(x1, y1, x3, y3, SOLID, TEXT_COLOR)
+		line(x1, y1, x2, y2, SOLID, data.set_flags(0, data.TextColor))
+		line(x1, y1, x3, y3, SOLID, data.set_flags(0, data.TextColor))
 	end
 
 	-- Box 4 (GPS info, speed)
 	if data.crsf then
 		if data.tpwr then
-			text(RIGHT_POS, TOP, data.tpwr .. "mW", RIGHT + MIDSIZE + data.telemFlags)
+		   text(RIGHT_POS, TOP, data.tpwr .. "mW", data.set_flags(RIGHT + MIDSIZE, telemCol))
 		end
-		text(RIGHT_POS + 1, TOP + 28, data.satellites % 100, MIDSIZE + RIGHT + data.telemFlags)
+		text(RIGHT_POS + 1, TOP + 28, data.satellites % 100, data.set_flags(MIDSIZE + RIGHT, telemCol))
 	else
 		tmp = ((data.armed or data.modeId == 6) and data.hdop < 11 - config[21].v * 2) or not data.telem
-		text(X3 + 48, TOP, (data.hdop == 0 and not data.gpsFix) and "-- --" or (9 - data.hdop) * 0.5 + 0.8, MIDSIZE + RIGHT + (tmp and FLASH or 0))
-		text(X3 + 11, TOP + 24, "HDOP", SMLSIZE)
-		text(RIGHT_POS + 1, TOP, data.satellites % 100, MIDSIZE + RIGHT + data.telemFlags)
+		text(X3 + 48, TOP, (data.hdop == 0 and not data.gpsFix) and "-- --" or (9 - data.hdop) * 0.5 + 0.8, data.set_flags(MIDSIZE + RIGHT, (tmp and RED or data.TextColor)))
+		text(X3 + 11, TOP + 24, "HDOP", data.set_flags(SMLSIZE, data.TextColor))
+		text(RIGHT_POS + 1, TOP, data.satellites % 100, data.set_flags(MIDSIZE + RIGHT, telemCol))
 	end
 	hdopGraph(X3 + 65, TOP + (data.crsf and 51 or 23))
-	tmp = RIGHT + ((not data.telem or not data.gpsFix) and FLASH or 0)
+	tmp = RIGHT + ((not data.telem or not data.gpsFix) and RED or data.TextColor)
 	if not data.crsf then
-		text(RIGHT_POS, TOP + 28, floor(data.gpsAlt + 0.5) .. (data.gpsAlt_unit == 10 and "'" or units[data.gpsAlt_unit]), MIDSIZE + tmp)
+	   text(RIGHT_POS, TOP + 28, floor(data.gpsAlt + 0.5) .. (data.gpsAlt_unit == 10 and "'" or units[data.gpsAlt_unit]), data.set_flags(MIDSIZE, tmp))
 	end
-	text(RIGHT_POS, TOP + 54, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lat) or gpsDegMin(data.gpsLatLon.lat, true), SMLSIZE + tmp)
-	text(RIGHT_POS, TOP + 74, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lon) or gpsDegMin(data.gpsLatLon.lon, false), SMLSIZE + tmp)
+	text(RIGHT_POS, TOP + 54, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lat) or gpsDegMin(data.gpsLatLon.lat, true), data.set_flags(SMLSIZE, tmp))
+	text(RIGHT_POS, TOP + 74, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lon) or gpsDegMin(data.gpsLatLon.lon, false), data.set_flags(SMLSIZE, tmp))
 	tmp = data.showMax and data.speedMax or data.speed
-	text(RIGHT_POS + 1, TOP + 98, tmp >= 99.5 and floor(tmp + 0.5) .. units[data.speed_unit] or frmt("%.1f", tmp) .. units[data.speed_unit], MIDSIZE + RIGHT + data.telemFlags)
+	text(RIGHT_POS + 1, TOP + 98, tmp >= 99.5 and floor(tmp + 0.5) .. units[data.speed_unit] or frmt("%.1f", tmp) .. units[data.speed_unit], data.set_flags(MIDSIZE + RIGHT, telemCol))
 
 	-- Dividers
-	color(CUSTOM_COLOR, DKGREY)
-	line(X2 + 3, TOP, X2 + 3, BOTTOM, SOLID, CUSTOM_COLOR)
-	line(X3 + 3, TOP, X3 + 3, BOTTOM, SOLID, CUSTOM_COLOR)
-	line(X3 + 3, TOP + 95, RIGHT_POS, TOP + 95, SOLID, CUSTOM_COLOR)
+	line(X2 + 3, TOP, X2 + 3, BOTTOM, SOLID, data.set_flags(0, DKGREY))
+	line(X3 + 3, TOP, X3 + 3, BOTTOM, SOLID, data.set_flags(0, DKGREY))
+	line(X3 + 3, TOP + 95, RIGHT_POS, TOP + 95, SOLID, data.set_flags(0, DKGREY))
 	if data.crsf then
-		line(X3 + 3, TOP + 28, RIGHT_POS, TOP + 28, SOLID, CUSTOM_COLOR)
+		line(X3 + 3, TOP + 28, RIGHT_POS, TOP + 28, SOLID, data.set_flags(0, DKGREY))
 	end
-	line(0, TOP - 1, LCD_W - 1, TOP - 1, SOLID, CUSTOM_COLOR)
+	line(0, TOP - 1, LCD_W - 1, TOP - 1, SOLID, data.set_flags(0, DKGREY))
 
 	if data.showMax then
-		color(CUSTOM_COLOR, YELLOW)
-		fill(240, TOP - 211, 80, 20, CUSTOM_COLOR)
-		color(CUSTOM_COLOR, BLACK)
-		text(319, TOP - 211, "Min/Max", CUSTOM_COLOR + RIGHT)
+	   fill(240, TOP - 211, 80, 20, data.set_flags(0, YELLOW))
+	   text(319, TOP - 211, "Min/Max", data.set_flags(RIGHT, BLACK))
 	end
 
 end

--- a/src/SCRIPTS/TELEMETRY/iNav/nirvana.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/nirvana.lua
@@ -136,11 +136,11 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	end
 
 	-- Draw ground
-	local gcol = GROUND
+	local gflag = data.set_flags(0, GROUND)
 	if skip then
 		-- Must be going down hard!
 		if (pitch - 90) * (upsideDown and -1 or 1) < 0 then
-		   fill(tl.x, tl.y, br.x - tl.x + 1, br.y - tl.y + 1, data.set_flags(0, gcol))
+		   fill(tl.x, tl.y, br.x - tl.x + 1, br.y - tl.y + 1, gflag)
 		end
 	else
 		local trix, triy
@@ -157,21 +157,21 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		-- Find rectangle(s) and fill
 		if upsideDown then
 			if triy > tl.y then
-				fill(tl.x, tl.y, br.x - tl.x + 1, triy - tl.y, data.set_flags(0, gcol))
+				fill(tl.x, tl.y, br.x - tl.x + 1, triy - tl.y, gflag)
 			end
 			if roll > 90 and trix < br.x then
-				fill(trix, triy, br.x - trix + 1, br.y - triy + 1, data.set_flags(0, gcol))
+				fill(trix, triy, br.x - trix + 1, br.y - triy + 1, gflag)
 			elseif roll <= 90 and trix > tl.x then
-				fill(tl.x, triy, trix - tl.x, br.y - triy + 1, data.set_flags(0, gcol))
+				fill(tl.x, triy, trix - tl.x, br.y - triy + 1, gflag)
 			end
 		else
 			if triy < br.y then
-				fill(tl.x, triy + 1, br.x - tl.x + 1, br.y - triy, data.set_flags(0, gcol))
+				fill(tl.x, triy + 1, br.x - tl.x + 1, br.y - triy, gflag)
 			end
 			if roll > 90 and trix > tl.x then
-				fill(tl.x, tl.y, trix - tl.x, triy - tl.y + 1, data.set_flags(0, gcol))
+				fill(tl.x, tl.y, trix - tl.x, triy - tl.y + 1, gflag)
 			elseif roll <= 90 and trix < br.x then
-				fill(trix, tl.y, br.x - trix + 1, triy - tl.y + 1, data.set_flags(0, gcol))
+				fill(trix, tl.y, br.x - trix + 1, triy - tl.y + 1, gflag)
 			end
 		end
 
@@ -199,14 +199,14 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			slope = abs(slope) * (tx1 < tx2 and 1 or -1)
 			for y = triy, top, steps do
 				if abs(steps) == 1 then
-					line(tx1, y, tx2, y, SOLID, data.set_flags(0, gcol))
+					line(tx1, y, tx2, y, SOLID, gflag)
 				else
 					if tx1 < tx2 then
 					--if tx1 < tx2 and tx2 - tx1 + 1 > 0 then
-						fill(tx1, y - s, tx2 - tx1 + 1, inc, data.set_flags(0, gcol))
+						fill(tx1, y - s, tx2 - tx1 + 1, inc, gflag)
 					else
 					--elseif tx1 > tx2 and tx1 - tx2 + 1 > 0 then
-						fill(tx2, y - s, tx1 - tx2 + 1, inc, data.set_flags(0, gcol))
+						fill(tx2, y - s, tx1 - tx2 + 1, inc, gflag)
 					end
 				end
 				tx1 = tx1 + slope
@@ -217,20 +217,20 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		if not upsideDown and inc <= 3 then
 			if inc > 1 then
 				if inc > 2 then
-					line(i[1].x, i[1].y + 2, i[2].x, i[2].y + 2, SOLID, data.set_flags(0, gcol))
+					line(i[1].x, i[1].y + 2, i[2].x, i[2].y + 2, SOLID, gflag)
 				end
-				line(i[1].x, i[1].y + 1, i[2].x, i[2].y + 1, SOLID, data.set_flags(0, gcol))
-				gcol = SKY
-				line(i[1].x, i[1].y - 1, i[2].x, i[2].y - 1, SOLID, data.set_flags(0, gcol))
+				line(i[1].x, i[1].y + 1, i[2].x, i[2].y + 1, SOLID, gflag)
+				gflag = data.set_flags(0, SKY)
+				line(i[1].x, i[1].y - 1, i[2].x, i[2].y - 1, SOLID, gflag)
 				if inc > 2 then
-					line(i[1].x, i[1].y - 2, i[2].x, i[2].y - 2, SOLID, data.set_flags(0, gcol))
+					line(i[1].x, i[1].y - 2, i[2].x, i[2].y - 2, SOLID, gflag)
 				end
 				if 90 - roll > 25 then
-					line(i[1].x, i[1].y - 3, i[2].x, i[2].y - 3, SOLID, data.set_flags(0, gcol))
+					line(i[1].x, i[1].y - 3, i[2].x, i[2].y - 3, SOLID, gflag)
 				end
 			end
-			gcol = LIGHTGREY
-			line(i[1].x, i[1].y, i[2].x, i[2].y, SOLID, data.set_flags(0, gcol))
+			gflag = data.set_flags(0, LIGHTGREY)
+			line(i[1].x, i[1].y, i[2].x, i[2].y, SOLID, gflag)
 		end
 	end
 
@@ -252,8 +252,9 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	if config[28].v == 0 then
 		tics(data.speed, 1)
 		tics(data.altitude, RIGHT_POS - 4)
-		text(42, Y_CNTR - 25, units[data.speed_unit], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
-		text(RIGHT_POS - 4, Y_CNTR - 25, "Alt " .. units[data.alt_unit], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
+		local smrf = data.set_flags(SMLSIZE + RIGHT, data.TextColor)
+		text(42, Y_CNTR - 25, units[data.speed_unit], smrf)
+		text(RIGHT_POS - 4, Y_CNTR - 25, "Alt " .. units[data.alt_unit], smrf)
 	end
 
 	-- Compass
@@ -264,7 +265,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 				if i % 45 == 0 then
 				   text(tmp, bot2, dir[i / 45], data.set_flags(CENTERED + SMLSIZE, data.TextColor))
 				else
-					line(tmp, BOTTOM - 4, tmp, BOTTOM - 1, SOLID, 0)
+					line(tmp, BOTTOM - 4, tmp, BOTTOM - 1, SOLID,  data.set_flags(0, data.TextColor))
 				end
 			end
 		end
@@ -344,9 +345,10 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		bmap(icons.roll, 43, 20)
 		if roll > 30 and roll < 150 and not upsideDown then
 			local x1, y1, x2, y2, x3, y3 = calcDir(rad(roll - 90), rad(roll + 55), rad(roll - 235), X_CNTR - (cos(roll1) * 75), 79 - (sin(roll1) * 40), 7)
-			line(x1, y1, x2, y2, SOLID, data.set_flags(0, YELLOW))
-			line(x1, y1, x3, y3, SOLID, data.set_flags(0, YELLOW))
-			line(x2, y2, x3, y3, SOLID, data.set_flags(0, YELLOW))
+			local ycol = data.set_flags(0, YELLOW)
+			line(x1, y1, x2, y2, SOLID, ycol)
+			line(x1, y1, x3, y3, SOLID, ycol)
+			line(x2, y2, x3, y3, SOLID, ycol)
 		end
 	end
 
@@ -456,7 +458,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 				--bmap(icons.home, hx - 4, hy - 5)
 				bmap(icons.home[1], hx - 8, hy - 10)
 			elseif d > 1 then
-				fill(hx - 1, hy - 1, 3, 3, SOLID)
+			   fill(hx - 1, hy - 1, 3, 3, SOLID, data.set_flags(0, data.TextColor))
 			end
 			-- Shift craft location
 			cx = d == 1 and X_CNTR + 2 or cx + hx
@@ -469,18 +471,21 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		-- Orientation
 		local x1, y1, x2, y2, x3, y3 = calcDir(r1, r2, r3, cx, cy, 8)
 		line(x2, y2, x3, y3, SOLID, data.set_flags(0, LIGHTGREY))
-		line(x1, y1, x2, y2, SOLID, data.set_flags(0, data.TextColor))
-		line(x1, y1, x3, y3, SOLID, data.set_flags(0, data.TextColor))
+		local tcol = data.set_flags(0, data.TextColor)
+		line(x1, y1, x2, y2, SOLID, tcol)
+		line(x1, y1, x3, y3, SOLID, tcol)
 		tmp = data.distanceLast < 1000 and floor(data.distanceLast + 0.5) .. units[data.dist_unit] or (frmt("%.1f", data.distanceLast / (data.dist_unit == 9 and 1000 or 5280)) .. (data.dist_unit == 9 and "km" or "mi"))
 		text(LEFT_POS + 2, BOTTOM - 16, tmp, data.set_flags(SMLSIZE, telemCol))
 	end
 
 	-- Startup message
 	if data.startup == 2 then
-	   text(X_CNTR - 78, 192, "Lua Telemetry", data.set_flags(MIDSIZE, BLACK))
-	   text(X_CNTR - 38, 222, "v" .. VERSION, data.set_flags(MIDSIZE, BLACK))
-	   text(X_CNTR - 79, 191, "Lua Telemetry", data.set_flags(MIDSIZE, data.TextColor))
-	   text(X_CNTR - 39, 221, "v" .. VERSION, data.set_flags(MIDSIZE, data.TextColor))
+	   local tcol = data.set_flags(MIDSIZE, BLACK)
+	   text(X_CNTR - 78, 192, "Lua Telemetry", tcol)
+	   text(X_CNTR - 38, 222, "v" .. VERSION, tcol)
+	   tcol = data.set_flags(MIDSIZE, data.TextColor)
+	   text(X_CNTR - 79, 191, "Lua Telemetry", tcol)
+	   text(X_CNTR - 39, 221, "v" .. VERSION, tcol)
 	end
 
 	-- Data
@@ -568,8 +573,9 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		else
 			line(x2, y2, x3, y3, SOLID, data.set_flags(0, DKGREY))
 		end
-		line(x1, y1, x2, y2, SOLID, data.set_flags(0, data.TextColor))
-		line(x1, y1, x3, y3, SOLID, data.set_flags(0, data.TextColor))
+		local tcol = data.set_flags(0, data.TextColor)
+		line(x1, y1, x2, y2, SOLID, tcol)
+		line(x1, y1, x3, y3, SOLID, tcol)
 	end
 
 	-- Box 4 (GPS info, speed)
@@ -589,19 +595,21 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	if not data.crsf then
 	   text(RIGHT_POS, TOP + 28, floor(data.gpsAlt + 0.5) .. (data.gpsAlt_unit == 10 and "'" or units[data.gpsAlt_unit]), data.set_flags(MIDSIZE, tmp))
 	end
-	text(RIGHT_POS, TOP + 54, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lat) or gpsDegMin(data.gpsLatLon.lat, true), data.set_flags(SMLSIZE, tmp))
-	text(RIGHT_POS, TOP + 74, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lon) or gpsDegMin(data.gpsLatLon.lon, false), data.set_flags(SMLSIZE, tmp))
+	local pcol = data.set_flags(SMLSIZE, tmp)
+	text(RIGHT_POS, TOP + 54, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lat) or gpsDegMin(data.gpsLatLon.lat, true), pcol)
+	text(RIGHT_POS, TOP + 74, config[16].v == 0 and frmt("%.6f", data.gpsLatLon.lon) or gpsDegMin(data.gpsLatLon.lon, false), pcol)
 	tmp = data.showMax and data.speedMax or data.speed
 	text(RIGHT_POS + 1, TOP + 98, tmp >= 99.5 and floor(tmp + 0.5) .. units[data.speed_unit] or frmt("%.1f", tmp) .. units[data.speed_unit], data.set_flags(MIDSIZE + RIGHT, telemCol))
 
 	-- Dividers
-	line(X2 + 3, TOP, X2 + 3, BOTTOM, SOLID, data.set_flags(0, DKGREY))
-	line(X3 + 3, TOP, X3 + 3, BOTTOM, SOLID, data.set_flags(0, DKGREY))
-	line(X3 + 3, TOP + 95, RIGHT_POS, TOP + 95, SOLID, data.set_flags(0, DKGREY))
+	local dkgcol = data.set_flags(0, DKGREY)
+	line(X2 + 3, TOP, X2 + 3, BOTTOM, SOLID, dkgcol)
+	line(X3 + 3, TOP, X3 + 3, BOTTOM, SOLID, dkgcol)
+	line(X3 + 3, TOP + 95, RIGHT_POS, TOP + 95, SOLID, dkgcol)
 	if data.crsf then
-		line(X3 + 3, TOP + 28, RIGHT_POS, TOP + 28, SOLID, data.set_flags(0, DKGREY))
+		line(X3 + 3, TOP + 28, RIGHT_POS, TOP + 28, SOLID, dkgcol)
 	end
-	line(0, TOP - 1, LCD_W - 1, TOP - 1, SOLID, data.set_flags(0, DKGREY))
+	line(0, TOP - 1, LCD_W - 1, TOP - 1, SOLID, dkgcol)
 
 	if data.showMax then
 	   fill(240, TOP - 211, 80, 20, data.set_flags(0, YELLOW))

--- a/src/SCRIPTS/TELEMETRY/iNav/other.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/other.lua
@@ -1,4 +1,4 @@
-local config, data, units, getTelemetryId, getTelemetryUnit, FILE_PATH, env, SMLCD, FLASH = ...
+local config, data, units, getTelemetryId, getTelemetryUnit, FILE_PATH, env, SMLCD = ...
 local crsf = nil
 
 -- Detect Crossfire
@@ -11,7 +11,7 @@ data.fm_id = getTelemetryId("FM") > -1 and getTelemetryId("FM") or getTelemetryI
 --data.nv = true
 
 if data.fm_id > -1 then
-	crsf = loadScript(FILE_PATH .. "crsf.luac", env)(config, data, getTelemetryId, FLASH)
+	crsf = loadScript(FILE_PATH .. "crsf.luac", env)(config, data, getTelemetryId)
 	collectgarbage()
 end
 

--- a/src/SCRIPTS/TELEMETRY/iNav/radar.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/radar.lua
@@ -1,5 +1,6 @@
-local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGraph, icons, calcBearing, calcDir, VERSION, SMLCD, FLASH, FILE_PATH, text, line, rect, fill, frmt)
+local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGraph, icons, calcBearing, calcDir, VERSION, SMLCD, FILE_PATH, text, line, rect, fill, frmt)
 
+   	local FLASH = 3 -- legecy
 	local LEFT_DIV = 36
 	local LEFT_POS = SMLCD and LEFT_DIV or 73
 	local RIGHT_POS = SMLCD and LCD_W - 31 or LCD_W - 53
@@ -30,6 +31,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	end
 	pitch = pitch >= 0 and (pitch < 1 and 0 or math.floor(pitch + 0.5)) or (pitch > -1 and 0 or math.ceil(pitch - 0.5))
 
+	local telemFlag = data.telem and 0 or FLASH
 	-- Bottom center
 	if SMLCD then
 		if data.showDir and (not data.armed or not data.telem) then
@@ -39,7 +41,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		else
 			-- Distance
 			tmp = data.showMax and data.distanceMax or data.distanceLast
-			text(LEFT_POS + 25, 57, data.startup > 0 and "Dist " or (tmp < 1000 and math.floor(tmp + 0.5) .. units[data.dist_unit] or (frmt("%.1f", tmp / (data.dist_unit == 9 and 1000 or 5280)) .. (data.dist_unit == 9 and "km" or "mi"))), SMLSIZE + RIGHT + data.telemFlags)
+			text(LEFT_POS + 25, 57, data.startup > 0 and "Dist " or (tmp < 1000 and math.floor(tmp + 0.5) .. units[data.dist_unit] or (frmt("%.1f", tmp / (data.dist_unit == 9 and 1000 or 5280)) .. (data.dist_unit == 9 and "km" or "mi"))), SMLSIZE + RIGHT + telemFlag)
 			-- Altitude
 			tmp = data.showMax and data.altitudeMax or data.altitude
 			text(RIGHT_POS, 57, data.startup > 0 and "Alt" or (math.floor(tmp + 0.5) .. units[data.alt_unit]), SMLSIZE + RIGHT + ((not data.telem or tmp + 0.5 >= config[6].v) and FLASH or 0))
@@ -49,14 +51,14 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		end
 		-- Pitch
 		if data.startup == 0 then
-			text(LEFT_POS + 15, 17, pitch .. (math.abs(pitch) < 10 and "\64" or ""), SMLSIZE + RIGHT + data.telemFlags)
+			text(LEFT_POS + 15, 17, pitch .. (math.abs(pitch) < 10 and "\64" or ""), SMLSIZE + RIGHT + telemFlag)
 			line(LEFT_POS + 1, 17, LEFT_POS + 1, 24, SOLID, ERASE)
 		else
 			text(LEFT_POS + 2, 17, "Ptch", SMLSIZE)
 		end
 	elseif data.showDir or data.headingRef == -1 then
 		-- Heading
-		text(X_CNTR + 14 - (data.heading < 100 and 3 or 0) - (data.heading < 10 and 3 or 0), 57, math.floor(data.heading + 0.5) % 360 .. "\64", SMLSIZE + RIGHT + data.telemFlags)
+		text(X_CNTR + 14 - (data.heading < 100 and 3 or 0) - (data.heading < 10 and 3 or 0), 57, math.floor(data.heading + 0.5) % 360 .. "\64", SMLSIZE + RIGHT + telemFlag)
 	end
 	-- Min/Max
 	if not data.showDir and data.showMax then
@@ -133,10 +135,10 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	end
 
 	-- Right data - GPS
-	text(LCD_W, data.crsf and 20 or 8, data.satellites % 100, MIDSIZE + RIGHT + data.telemFlags)
+	text(LCD_W, data.crsf and 20 or 8, data.satellites % 100, MIDSIZE + RIGHT + telemFlag)
 	icons.gps(LCD_W - (SMLCD and 23 or 22), data.crsf and 24 or 12)
 	if data.crsf then
-		text(LCD_W, SMLCD and 9 or 11, data.tpwr < 1000 and data.tpwr .. "mW" or data.tpwr * 0.001 .. "W", SMLSIZE + RIGHT + data.telemFlags)
+		text(LCD_W, SMLCD and 9 or 11, data.tpwr < 1000 and data.tpwr .. "mW" or data.tpwr * 0.001 .. "W", SMLSIZE + RIGHT + telemFlag)
 	else
 		text(LCD_W + 1, SMLCD and 43 or 24, math.floor(data.gpsAlt + 0.5) .. units[data.gpsAlt_unit], gpsFlags)
 	end
@@ -175,12 +177,12 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	text(LEFT_DIV, data.showCurr and 34 or 41, "V", SMLSIZE + RIGHT + tmp)
 	if data.showCurr then
 		tmp = data.showMax and data.currentMax or data.current
-		text(LEFT_DIV - 5, 42, tmp >= 99.5 and math.floor(tmp + 0.5) or frmt("%.1f", tmp), MIDSIZE + RIGHT + data.telemFlags)
-		text(LEFT_DIV, 47, "A", SMLSIZE + RIGHT + data.telemFlags)
+		text(LEFT_DIV - 5, 42, tmp >= 99.5 and math.floor(tmp + 0.5) or frmt("%.1f", tmp), MIDSIZE + RIGHT + telemFlag)
+		text(LEFT_DIV, 47, "A", SMLSIZE + RIGHT + telemFlag)
 	end
 	line(0, data.showCurr and 55 or 53, LEFT_DIV, data.showCurr and 55 or 53, SOLID, FORCE)
 	tmp = data.showMax and data.speedMax or data.speed
-	text(LEFT_DIV, data.showCurr and 57 or 56, tmp >= 99.5 and math.floor(tmp + 0.5) .. units[data.speed_unit] or frmt("%.1f", tmp) .. units[data.speed_unit], SMLSIZE + RIGHT + data.telemFlags)
+	text(LEFT_DIV, data.showCurr and 57 or 56, tmp >= 99.5 and math.floor(tmp + 0.5) .. units[data.speed_unit] or frmt("%.1f", tmp) .. units[data.speed_unit], SMLSIZE + RIGHT + telemFlag)
 
 	-- Left data - Wide screen
 	if not SMLCD then
@@ -198,13 +200,13 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		tmp = data.showMax and data.distanceMax or data.distanceLast
 		tmp2 = data.dist_unit == 9 and (tmp < 1000 and 6 or 11) or (tmp < 1000 and 2 or 10)
 		text(LEFT_DIV + 2, 30, "Dist", SMLSIZE)
-		text(LEFT_POS - tmp2, (data.dist_unit == 9 or tmp >= 1000) and 42 or 38, tmp < 1000 and units[data.dist_unit] or (data.dist_unit == 9 and "km" or "mi"), SMLSIZE + data.telemFlags)
-		text(LEFT_POS - tmp2, 37, tmp < 1000 and math.floor(tmp + 0.5) or frmt("%.1f", tmp / (data.dist_unit == 9 and 1000 or 5280)), MIDSIZE + RIGHT + data.telemFlags)
+		text(LEFT_POS - tmp2, (data.dist_unit == 9 or tmp >= 1000) and 42 or 38, tmp < 1000 and units[data.dist_unit] or (data.dist_unit == 9 and "km" or "mi"), SMLSIZE + telemFlag)
+		text(LEFT_POS - tmp2, 37, tmp < 1000 and math.floor(tmp + 0.5) or frmt("%.1f", tmp / (data.dist_unit == 9 and 1000 or 5280)), MIDSIZE + RIGHT + telemFlag)
 		--Pitch
 		line(LEFT_DIV, 50, LEFT_POS, 50, SOLID, FORCE)
 		text(LEFT_DIV + 5, 54, pitch > 0 and "\194" or (pitch == 0 and "->" or "\195"), SMLSIZE)
-		text(LEFT_POS, 53, "\64", SMLSIZE + RIGHT + data.telemFlags)
-		text(LEFT_POS - 4, 52, pitch, MIDSIZE + RIGHT + data.telemFlags)
+		text(LEFT_POS, 53, "\64", SMLSIZE + RIGHT + telemFlag)
+		text(LEFT_POS - 4, 52, pitch, MIDSIZE + RIGHT + telemFlag)
 	end
 end
 


### PR DESCRIPTION
This is phase two of the EdgeTX compatibility work.
* Do not use any system theme elements on EdgeTX, only use `CUSTOM_COLOR` on OpenTX.
* Does not modify (or restore) any system theme elements (other than `CUSTOM_COLOR` on OpenTX, which appears unavoidable).
* Greatly speeds up EdgeTX swiping speed over 2.0.0; caches repeated colour / flag settings.
* Coexists cleanly with other complex widgets (like Yappu).
* Includes a developer guide detailing how to maintain ETX / OTX compatibility.

Independently tested by a couple of users on the EdgeTX discord.

Fixes #12 and https://github.com/EdgeTX/edgetx/issues/823