### PR TITLE
account for kerning differences OTX/ETX

### DIFF
--- a/src/SCRIPTS/TELEMETRY/iNav/func_h.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/func_h.lua
@@ -215,9 +215,32 @@ function data.menu(prev)
 	end
 	-- Return throttle stick to bottom center
 	if data.stickMsg ~= nil and not data.armed then
-	   fill(data.nv and 6 or 20, data.nv and 270 or 128, data.nv and 308 or 439, 30, data.set_flags(0, BLACK))
-	   rect(data.nv and 5 or 19, data.nv and 269 or 127, data.nv and 310 or 441, 32, data.set_flags(0, OYELLOW))
-	   text(data.nv and 14 or 28, data.nv and 275 or 128, data.stickMsg, data.set_flags(data.nv and SMLSIZE or MIDSIZE, OYELLOW))
+	   local tflags = data.set_flags(data.nv and SMLSIZE or MIDSIZE, OYELLOW)
+	   local ox,oy, oh, ow, ty
+	   if data.etx then -- takes flags into account for sizing
+	      fw,fh = lcd.sizeText(data.stickMsg, tflags)
+	      oh = fh + 2
+	      ow = fw + 16
+	      ox = (LCD_W - ow) / 2 - 1
+	      oy = (LCD_H - fh) / 2 - 2
+	      ty = oy + 1
+	   else
+	      if data.nv then
+		 ox = 6
+		 oy = 270
+		 ow = 308
+		 ty = 275
+	      else
+		 ox = 20
+		 oy = 128
+		 ow = 439
+		 ty = 128
+	      end
+	      oh = 30
+	   end
+	   fill(ox, oy, ow, oh, data.set_flags(0, BLACK))
+	   rect(ox-1, oy - 1, ow+2, oh + 2, data.set_flags(0, OYELLOW))
+	   text(ox+8, ty, data.stickMsg, tflags)
 	end
 end
 


### PR DESCRIPTION
Due to font kenning differences between OpenTX and EddeTX, the colour radio "Return stick ..." message looks really ugly in EdgeTX

OTX
![otx-message](https://user-images.githubusercontent.com/158229/137139971-0bfd507f-5ec6-49a9-b2d8-408f285820e1.png)

ETX
![etx-message](https://user-images.githubusercontent.com/158229/137140059-d75f78ab-4f67-41ce-8751-0985cea444f4.png)

 This PR uses the EdgeTX `lcd.sizeText` API to determine the correct sizing and location.
![ETX-fixed](https://user-images.githubusercontent.com/158229/137140494-f51b1da8-0cf7-4e14-b9bf-3aadfbc4e1d2.png)
