### PR TITLE
workaround edge2.6 getFieldInfo breakage

### DIFF
--- a/src/SCRIPTS/TELEMETRY/iNav.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav.lua
@@ -2,7 +2,7 @@
 -- Docs: https://github.com/iNavFlight/OpenTX-Telemetry-Widget
 
 local zone, options = ...
-local VERSION = "2.0.1"
+local VERSION = "2.0.2"
 local FILE_PATH = "/SCRIPTS/TELEMETRY/iNav/"
 local SMLCD = LCD_W < 212
 local HORUS = LCD_W >= 480 or LCD_H >= 480

--- a/src/SCRIPTS/TELEMETRY/iNav/data.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/data.lua
@@ -6,8 +6,8 @@ local function getTelemetryId(n)
 end
 
 local function getTelemetryUnit(n)
-	local field = getFieldInfo(n)
-	return (field and field.unit <= 10) and field.unit or 0
+   local field = getFieldInfo(n)
+   return (field and field.unit and field.unit <= 10) and field.unit or 0
 end
 
 --[[	Replace with EVT_VIRTUAL_XXX at begining of 2020 and require OpenTX 2.3+


### PR DESCRIPTION
Fixes #23 
**Don't release yet**, in case they break more backwards compatibility prior to the 2.6 release