### PR TITLE
revert ETX 2.6rc2 workaround (fixed in ETX)

### DIFF
--- a/src/SCRIPTS/TELEMETRY/iNav.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav.lua
@@ -2,7 +2,7 @@
 -- Docs: https://github.com/iNavFlight/OpenTX-Telemetry-Widget
 
 local zone, options = ...
-local VERSION = "2.0.2-rc2"
+local VERSION = "2.0.2-rc3"
 local FILE_PATH = "/SCRIPTS/TELEMETRY/iNav/"
 local SMLCD = LCD_W < 212
 local HORUS = LCD_W >= 480 or LCD_H >= 480

--- a/src/SCRIPTS/TELEMETRY/iNav/data.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/data.lua
@@ -7,7 +7,7 @@ end
 
 local function getTelemetryUnit(n)
    local field = getFieldInfo(n)
-   return (field and field.unit and field.unit <= 10) and field.unit or 0
+   return (field and field.unit <= 10) and field.unit or 0
 end
 
 --[[	Replace with EVT_VIRTUAL_XXX at begining of 2020 and require OpenTX 2.3+


### PR DESCRIPTION
This PR removes the workaround for the  ETX 2.6rc2 `getfieldInfo()`  regression, as this will be fixed in the ETX 2.6 release (which has now been tagged).
