### PR TITLE
support RM Zorro radio

### DIFF
--- a/src/SCRIPTS/TELEMETRY/iNav.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav.lua
@@ -2,7 +2,7 @@
 -- Docs: https://github.com/iNavFlight/OpenTX-Telemetry-Widget
 
 local zone, options = ...
-local VERSION = "2.0.2-rc4"
+local VERSION = "2.0.2-rc5"
 local FILE_PATH = "/SCRIPTS/TELEMETRY/iNav/"
 local SMLCD = LCD_W < 212
 local HORUS = LCD_W >= 480 or LCD_H >= 480

--- a/src/SCRIPTS/TELEMETRY/iNav/data.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/data.lua
@@ -31,6 +31,8 @@ elseif string.sub(r, 0, 3) == "t12" then
    MENU = EVT_VIRTUAL_MENU_LONG
 elseif string.sub(r,0,5) == "tlite" then
    MENU = EVT_VIRTUAL_MENU_LONG
+elseif string.sub(r,0,5) == "zorro" then
+   MENU = EVT_VIRTUAL_MENU_LONG
 else
    MENU = EVT_MENU_BREAK
 end


### PR DESCRIPTION
Support the RM Zorro radio.

Widget confguration is entered entered by a long press on the roller.
Dismiss the "Reset" menu with "RTN".
Access the options via the roller.
