### PR TITLE
Launch Based Orientation Display Marker - Repair

### DIFF
--- a/src/SCRIPTS/TELEMETRY/iNav.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav.lua
@@ -251,7 +251,7 @@ function inav.background()
 	local beep = false
 	if data.armed and not armedPrev then -- Engines armed
 		data.timerStart = getTime()
-
+		data.headingRef = data.heading
 		data.gpsHome = false
 		data.battPercentPlayed = 100
 		data.battLow = false


### PR DESCRIPTION
The launch orientation display is not currently working (v2.1.1-rc1) on the 480 x 272 color LCD display radios.
If "Launch" is selected (default) in the configuration, the orientation marker would change after arming to the direction of launch.
I searched this problem back and it stopped working after commit b34284a dated Sept 24, 2021.

Adding this removed line back into inav.lua has this launch based orientation option working again.

Thanks - Rich