### PR TITLE
Add check for 2RSS to improve functionality with ELRS true diversity receivers

### DIFF
--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -20,15 +20,10 @@ config[22].v = 0
 config[23].x = 1
 
 local function crsf(data)
-	if getValue(data.rssi_id) == 0 or getValue(data.rssi_id) == nil then
-		--[[ Also check for RSSI2, in case RSSI2 is active with RSSI1 being inactive
-			 (Sometimes happens with True Diversity ELRS receivers on startup) ]]
-		local rssi2 = getTelemetryId("2RSS")
-		if getValue(rssi2) == 0 or getValue(rssi2) == nil then
-			data.rssi = 0
-			data.telem = false
-			return 0
-		end
+	if getValue(data.tpwr_id) == 0 then
+		data.rssi = 0
+		data.telem = false
+		return 0
 	end
 	if data.rssi == 99 then data.rssi = 100 end
 	data.tpwr = getValue(data.tpwr_id)

--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -20,7 +20,7 @@ config[22].v = 0
 config[23].x = 1
 
 local function crsf(data)
-	if getValue(data.rssi_id) == 0 then
+	if getValue(data.rssi_id) == 0 or getValue(data.rssi_id) == nil then
 		--[[ Also check for RSSI2, in case RSSI2 is active with RSSI1 being inactive
 			 (Sometimes happens with True Diversity ELRS receivers on startup) ]]
 		local rssi2 = getTelemetryId("2RSS")

--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -21,9 +21,14 @@ config[23].x = 1
 
 local function crsf(data)
 	if getValue(data.rssi_id) == 0 then
-		data.rssi = 0
-		data.telem = false
-		return 0
+		--[[ Also check for RSSI2, in case RSSI2 is active with RSSI1 being inactive
+			 (Sometimes happens with True Diversity ELRS receivers on startup) ]]
+		local rssi2 = getTelemetryId("2RSS")
+		if getValue(rssi2) == 0 or getValue(rssi2) == nil then
+			data.rssi = 0
+			data.telem = false
+			return 0
+		end
 	end
 	if data.rssi == 99 then data.rssi = 100 end
 	data.tpwr = getValue(data.tpwr_id)


### PR DESCRIPTION
ELRS True diversity receivers only have one "side" active at a time (they are actually two Rx's with their own individual antennas on the same PCB, and switch which "side" is active based on signal strength) , so they report either 1RSS or 2RSS, with the other sometimes being 0, specially at startup. 

If, during startup, only 2RSS is active and reported, the widget doesn't recognize the Rx connection and considers as "No telemetry active" since it only checks for a non-zero value in 1RSS (which, being inactive, is reported as 0). When, in fact, there is telemetry active and being sent normally, it is just coming via the 2RSS "side". 

In cases like this, depending on the Rx environment, it can take a while until the 1RSS "side" is activated (it will usually only be once the RF link strength on the 2RSS "side" falls significantly). But since the 2RSS "side" is active and working properly, the widget behavior can be weird or misleading. This is the behavior I experienced with two distinct Happymodel EP1 Dual TCXO's ELRS RX units.

This change aims to fix that, by checking that both 1RSS and 2RSS are zero before considering that there is no telemetry present. If either of them is non-zero (i.e. active), it considers as a normal connection.

I have tested with both EP1 Duals and some other non-diversity ELRS Rx's and it seems to work properly, but further testing is more than welcome. Specially testing with TBS Crossfire RX's, which I don't own any and can't test to see if my changes to the code break any functionality with them.
