### PR TITLE
Don't enumerate or load logs on non-colour radios, EdgeTX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on: [pull_request, push]
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies
@@ -35,7 +35,7 @@ jobs:
 
   test:
     needs: [build]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Run
         run: true

--- a/src/SCRIPTS/TELEMETRY/iNav.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav.lua
@@ -2,7 +2,7 @@
 -- Docs: https://github.com/iNavFlight/OpenTX-Telemetry-Widget
 
 local zone, options = ...
-local VERSION = "2.2.0+e3"
+local VERSION = "2.2.0+log"
 local FILE_PATH = "/SCRIPTS/TELEMETRY/iNav/"
 local SMLCD = LCD_W < 212
 local HORUS = LCD_W >= 480 or LCD_H >= 480
@@ -34,6 +34,9 @@ collectgarbage()
 data.etx = osname ~= nil and osname == "EdgeTX"
 
 loadScript(FILE_PATH .. "load_" .. (data.etx and "e" or "o") .. ext, env)(config, data, FILE_PATH)
+if data.etx and HORUS then
+   loadScript(FILE_PATH .. "load_ec" .. ext, env)(config, data, FILE_PATH)
+end
 collectgarbage()
 
 --[[ Simulator language testing

--- a/src/SCRIPTS/TELEMETRY/iNav/load_e.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/load_e.lua
@@ -22,36 +22,3 @@ if fh ~= nil then
    data.lang = tmp
    data.voice = tmp
 end
-
-local log = getDateTime()
-config[34].x = -1
-
--- From EdgeTX 2.7.1 (at least) we don't need to translate spaces
-local mbase = model.getInfo().name .. "-20"
-local mblen = string.len(mbase)
-local tempf = {}
-local tempi = 0
-for fname in  dir("/LOGS") do
-   if string.find(fname, mbase, 1, true) == 1 then
-      local dstr = string.sub(fname, mblen+1, -5)
-      local lyr = tonumber(string.sub(dstr, 1, 2))+2000
-      local lmo = tonumber(string.sub(dstr, 4, 5))
-      local lda = tonumber(string.sub(dstr, 7, 8))
-      tdiff = 366*(log.year-lyr) + (log.mon-lmo)*31 + log.day - lda
-      if tdiff < 16 then
-	 tempi = tempi + 1
-	 tempf[tempi] = dstr
-      end
-   end
-end
-if tempi > 0 then
-   table.sort( tempf )
-   for i = #tempf, 1, -1 do
-      config[34].x = config[34].x + 1
-      config[34].l[config[34].x] = tempf[i]
-      collectgarbage()
-      if config[34].x == 5 then break end
-   end
-end
-collectgarbage()
-return

--- a/src/SCRIPTS/TELEMETRY/iNav/load_ec.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/load_ec.lua
@@ -1,0 +1,37 @@
+-- Log loader for EdgeTX, Colour radios
+-- Not used on B&W radios due to missing table APIs
+
+local config, data, FILE_PATH = ...
+
+local log = getDateTime()
+config[34].x = -1
+
+-- From EdgeTX 2.7.1 (at least) we don't need to translate spaces
+local mbase = model.getInfo().name .. "-20"
+local mblen = string.len(mbase)
+local tempf = {}
+local tempi = 0
+for fname in  dir("/LOGS") do
+   if string.find(fname, mbase, 1, true) == 1 then
+      local dstr = string.sub(fname, mblen+1, -5)
+      local lyr = tonumber(string.sub(dstr, 1, 2))+2000
+      local lmo = tonumber(string.sub(dstr, 4, 5))
+      local lda = tonumber(string.sub(dstr, 7, 8))
+      tdiff = 366*(log.year-lyr) + (log.mon-lmo)*31 + log.day - lda
+      if tdiff < 16 then
+	 tempi = tempi + 1
+	 tempf[tempi] = dstr
+      end
+   end
+end
+if tempi > 0 then
+   table.sort( tempf )
+   for i = #tempf, 1, -1 do
+      config[34].x = config[34].x + 1
+      config[34].l[config[34].x] = tempf[i]
+      collectgarbage()
+      if config[34].x == 5 then break end
+   end
+end
+collectgarbage()
+return


### PR DESCRIPTION
Various changes / mis-features in EdgeTX result in the widget crashing on non-colour radios with a populated `LOG` directory.