### PR TITLE
[edgetx] work around ETX character set changes

### DIFF
--- a/src/SCRIPTS/TELEMETRY/iNav.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav.lua
@@ -2,7 +2,7 @@
 -- Docs: https://github.com/iNavFlight/OpenTX-Telemetry-Widget
 
 local zone, options = ...
-local VERSION = "2.2.2"
+local VERSION = "2.2.3"
 local FILE_PATH = "/SCRIPTS/TELEMETRY/iNav/"
 local SMLCD = LCD_W < 212
 local HORUS = LCD_W >= 480 or LCD_H >= 480

--- a/src/SCRIPTS/TELEMETRY/iNav/func_h.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/func_h.lua
@@ -1,6 +1,7 @@
 local config, data, modes, dir, SMLCD, FILE_PATH, text, line, rect, fill, frmt, opts = ...
 
 local OYELLOW = data.RGB(255, 220, 16) -- common across ETX/OTX
+local DEGSYM = data.etx and "°" or "@"
 
 data.TextColor = opts.Text
 data.WarningColor = opts.Warn
@@ -102,7 +103,7 @@ end
 local function gpsDegMin(c, lat)
 	local gpsD = math.floor(math.abs(c))
 	local gpsM = math.floor((math.abs(c) - gpsD) * 60)
-	return frmt(data.nv and "%d\64%d'%04.1f\"" or "%d\64%d'%05.2f\"", gpsD, gpsM, ((math.abs(c) - gpsD) * 60 - gpsM) * 60) .. (lat and (c >= 0 and dir[0] or dir[4]) or (c >= 0 and dir[2] or dir[6]))
+	return frmt(data.nv and "%d"..DEGSYM.."%d'%04.1f\"" or "%d"..DEGSYM.."%d'%05.2f\"", gpsD, gpsM, ((math.abs(c) - gpsD) * 60 - gpsM) * 60) .. (lat and (c >= 0 and dir[0] or dir[4]) or (c >= 0 and dir[2] or dir[6]))
 end
 
 local function hdopGraph(x, y)

--- a/src/SCRIPTS/TELEMETRY/iNav/horus.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/horus.lua
@@ -33,6 +33,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	local sin = math.sin
 	local cos = math.cos
 	local OYELLOW = data.RGB(255, 220, 16) -- common across ETX/OTX
+	local DEGSYM = data.etx and "°" or "@"
 
 	function intersect(s1, e1, s2, e2)
 		local d = (s1.x - e1.x) * (s2.y - e2.y) - (s1.y - e1.y) * (s2.x - e2.x)
@@ -244,7 +245,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		end
 
 		if not data.showMax then
-		   text(X_CNTR - 65, Y_CNTR - 9, frmt("%.0f", upsideDown and -tmp or tmp) .. "\64", data.set_flags(SMLSIZE + RIGHT, data.TextColor))
+		   text(X_CNTR - 65, Y_CNTR - 9, frmt("%.0f", upsideDown and -tmp or tmp) .. DEGSYM, data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 		end
 	end
 
@@ -339,7 +340,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 
 	-- Heading
 	if data.showHead then
-	   text(X_CNTR + 18, bot2, floor(data.heading + 0.5) % 360 .. "\64", data.set_flags(SMLSIZE + RIGHT, telemCol))
+	   text(X_CNTR + 18, bot2, floor(data.heading + 0.5) % 360 .. DEGSYM, data.set_flags(SMLSIZE + RIGHT, telemCol))
 	end
 
 	-- Roll scale
@@ -546,7 +547,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		   text(tmp, TOP + 18, dir[0], data.set_flags(CENTERED + SMLSIZE, data.TextColor))
 		   text(X3 - 4, 211, dir[2], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 		   text(X2 + 10, 211, dir[6], data.set_flags(SMLSIZE, data.TextColor))
-			text(tmp + 4, BOTTOM - 15, floor(data.heading + 0.5) % 360 .. "\64", data.set_flags(CENTERED + SMLSIZE, telemCol))
+			text(tmp + 4, BOTTOM - 15, floor(data.heading + 0.5) % 360 .. DEGSYM, data.set_flags(CENTERED + SMLSIZE, telemCol))
 		end
 		local x1, y1, x2, y2, x3, y3 = calcDir(r1, r2, r3, tmp, 219, 25)
 		if data.headingHold then

--- a/src/SCRIPTS/TELEMETRY/iNav/nirvana.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/nirvana.lua
@@ -33,6 +33,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	local sin = math.sin
 	local cos = math.cos
 	local OYELLOW = data.RGB(255, 220, 16) -- common across ETX/OTX
+	local DEGSYM = data.etx and "°" or "@"
 
 	function intersect(s1, e1, s2, e2)
 		local d = (s1.x - e1.x) * (s2.y - e2.y) - (s1.y - e1.y) * (s2.x - e2.x)
@@ -245,7 +246,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			end
 		end
 		if not data.showMax then
-		   text(X_CNTR - 60, Y_CNTR - 10, frmt("%.0f", upsideDown and -tmp or tmp) .. "\64", data.set_flags(SMLSIZE + RIGHT, data.TextColor))
+		   text(X_CNTR - 60, Y_CNTR - 10, frmt("%.0f", upsideDown and -tmp or tmp) .. DEGSYM, data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 		end
 	end
 
@@ -338,7 +339,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 
 	-- Heading
 	if data.showHead then
-	   text(X_CNTR + 20, bot2, floor(data.heading + 0.5) % 360 .. "\64", data.set_flags(SMLSIZE + RIGHT, telemCol))
+	   text(X_CNTR + 20, bot2, floor(data.heading + 0.5) % 360 .. DEGSYM, data.set_flags(SMLSIZE + RIGHT, telemCol))
 	end
 
 	-- Roll scale
@@ -566,7 +567,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		   text(tmp, TOP + 18, dir[0], data.set_flags(CENTERED + SMLSIZE, data.TextColor))
 		   text(X3 - 4, 421, dir[2], data.set_flags(SMLSIZE + RIGHT, data.TextColor))
 		   text(X2 + 10, 421, dir[6], data.set_flags(SMLSIZE, data.TextColor))
-		   text(tmp + 4, BOTTOM - 15, floor(data.heading + 0.5) % 360 .. "\64", data.set_flags(CENTERED + SMLSIZE, telemCol))
+		   text(tmp + 4, BOTTOM - 15, floor(data.heading + 0.5) % 360 .. DEGSYM, data.set_flags(CENTERED + SMLSIZE, telemCol))
 		end
 		local x1, y1, x2, y2, x3, y3 = calcDir(r1, r2, r3, tmp, 429, 25)
 		if data.headingHold then


### PR DESCRIPTION
EdgeTX 2.9 introduced a new, non-backwards compatible character set change for **colour** radios, removing the automagic translation of `@` to `°`.

This PR hopefully fixes it.