### PR TITLE
add greyscale on/off option (for monochrome displays)

### DIFF
--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -88,6 +88,7 @@ Note also that on some of the smaller B&W radios (Boxer, Zorro, TX12) with a rol
   * **GPS Warning** - GPS accuracy (HDOP) to trigger warning (default: > 3.5 HDOP [at least 1 bar])
   * **GPS** - GPS coordinates as decimal or degrees/minutes format (default: Decimal)
   * **Playback Log** - Playback telemetry log files (latest 5 logs from the last 2 weeks) **[[help](../Configuration-Settings/#playback-telemetry-log-files)]**
+  * **Greyscale Gfx** - Turn on/off the use of greyscale display graphics (only for monochrome displays)
 
 ### Suggested Battery Settings
 #### Voltage and Current Calibration

--- a/src/SCRIPTS/TELEMETRY/iNav/alt.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/alt.lua
@@ -62,12 +62,12 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		-- Altitude graph
 		local BOTTOM = SMLCD and 47 or 63
 		tmp = (SMLCD and 30 or 40) / (data.altMax - data.altMin)
-		line(RIGHT_POS - 60, BOTTOM,  RIGHT_POS - 1, BOTTOM, SOLID, SMLCD and FORCE or GREY_DEFAULT + FORCE)
+		line(RIGHT_POS - 60, BOTTOM,  RIGHT_POS - 1, BOTTOM, SOLID, (SMLCD or config[35].v == 1) and FORCE or GREY_DEFAULT + FORCE)
 		for i = 1, 60 do
 			local cx = RIGHT_POS - 61 + i
 			local cy = math.floor(BOTTOM - (data.alt[((data.altCur - 2 + i) % 60) + 1] - data.altMin) * tmp)
 			if cy < BOTTOM then
-				line(cx, cy, cx, BOTTOM - 1, SOLID, SMLCD and FORCE or GREY_DEFAULT + FORCE)
+				line(cx, cy, cx, BOTTOM - 1, SOLID, (SMLCD or config[35].v == 1) and FORCE or GREY_DEFAULT + FORCE)
 			end
 			if (i ~= 1 or not SMLCD) and (i - 1) % (60 / config[28].v) == 0 then
 				line(cx, BOTTOM - (SMLCD and 30 or 40), cx, BOTTOM, DOTTED, 0)
@@ -97,7 +97,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			if data.headingHold then
 				fill((x2 + x3) * 0.5 - 1, (y2 + y3) * 0.5 - 1, 3, 3, SOLID)
 			else
-				line(x2, y2, x3, y3, SMLCD and DOTTED or SOLID, FORCE + (SMLCD and 0 or GREY_DEFAULT))
+				line(x2, y2, x3, y3, SMLCD and DOTTED or SOLID, FORCE + ((SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT))
 			end
 			line(x1, y1, x2, y2, SOLID, FORCE)
 			line(x1, y1, x3, y3, SOLID, FORCE)
@@ -108,7 +108,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	if config[7].v % 2 == 1 then
 		line(RIGHT_POS, 8, RIGHT_POS, 63, SOLID, FORCE)
 		line(RIGHT_POS + (SMLCD and 4 or 6), 8, RIGHT_POS + (SMLCD and 4 or 6), 63, SOLID, FORCE)
-		line(RIGHT_POS + 1, 35, RIGHT_POS + (SMLCD and 3 or 5), 35, SMLCD and DOTTED or SOLID, SMLCD and 0 or GREY_DEFAULT)
+		line(RIGHT_POS + 1, 35, RIGHT_POS + (SMLCD and 3 or 5), 35, SMLCD and DOTTED or SOLID, (SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT)
 		if data.armed then
 			tmp = math.log(1 + math.min(math.abs(0.6 * (data.vspeed_unit == 6 and data.vspeed * 0.3048 or data.vspeed)), 10)) * (data.vspeed < 0 and -1 or 1)
 			local y1 = 36 - (tmp * 11)
@@ -132,9 +132,9 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		if data.crsf == false then
 			text(LCD_W + 1, config[22].v == 0 and 32 or 22, "HDOP", RIGHT + SMLSIZE)
 		end
-		hdopGraph(LCD_W - 12, config[22].v == 0 and (data.crsf and 37 or 24) or 31, MIDSIZE, SMLCD)
+		hdopGraph(LCD_W - 12, config[22].v == 0 and (data.crsf and 37 or 24) or 31, MIDSIZE, (SMLCD or config[35].v == 1))
 	else
-		hdopGraph(LCD_W - 39, data.crsf and 24 or 10, MIDSIZE, SMLCD)
+		hdopGraph(LCD_W - 39, data.crsf and 24 or 10, MIDSIZE, (SMLCD or config[35].v == 1))
 		if data.crsf == false then
 			text(LCD_W - (config[22].v == 0 and 24 or 25), config[22].v == 0 and 18 or 20, "HDOP", RIGHT + SMLSIZE)
 		end

--- a/src/SCRIPTS/TELEMETRY/iNav/config.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/config.lua
@@ -36,6 +36,7 @@ local config = {
 	{ o = 30, c = 1, v = 0 }, -- Orientation - 32
 	{ o = 26, c = 1, v = 0 }, -- Roll Scale - 33
 	{ o = 34, c = 1, v = 0, l = {[0] = "?"}, x = -1 }, -- Review Log Date - 34
+	{ o = 35, c = 1, v = 0 }, -- Force Monochrome - 35
 }
 
 for i = 1, #config do

--- a/src/SCRIPTS/TELEMETRY/iNav/config.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/config.lua
@@ -36,7 +36,7 @@ local config = {
 	{ o = 30, c = 1, v = 0 }, -- Orientation - 32
 	{ o = 26, c = 1, v = 0 }, -- Roll Scale - 33
 	{ o = 34, c = 1, v = 0, l = {[0] = "?"}, x = -1 }, -- Review Log Date - 34
-	{ o = 35, c = 1, v = 0 }, -- Force Monochrome - 35
+	{ o = 35, c = 1, v = 0 }, -- Greyscale toggle - 35
 }
 
 for i = 1, #config do

--- a/src/SCRIPTS/TELEMETRY/iNav/menu.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/menu.lua
@@ -44,7 +44,7 @@ local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId,
 		{ t = "Orientation",      l = {[0] = "Launch", "Compass"} }, -- 32
 		{ t = "Roll Scale",       l = 1 }, -- 33
 		{ t = "Playback Log",     l = config[34].l }, -- 34
-		{ t = "Greyscale Gfx",       l = {[0] = "On", "Off"} }, -- 35
+		{ t = "Greyscale Gfx",    l = {[0] = "On", "Off"} }, -- 35
 	}
 
 	-- Import language changes

--- a/src/SCRIPTS/TELEMETRY/iNav/menu.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/menu.lua
@@ -44,6 +44,7 @@ local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId,
 		{ t = "Orientation",      l = {[0] = "Launch", "Compass"} }, -- 32
 		{ t = "Roll Scale",       l = 1 }, -- 33
 		{ t = "Playback Log",     l = config[34].l }, -- 34
+		{ t = "Greyscale Gfx",       l = {[0] = "On", "Off"} }, -- 35
 	}
 
 	-- Import language changes
@@ -78,6 +79,7 @@ local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId,
 	config2[23].p = not data.showFuel and 1 or nil
 	config2[24].p = data.crsf and 1 or (config[7].v < 2 and 1 or nil)
 	config2[27].p = (not data.crsf or config[23].v > 0) and 1 or nil
+	config2[35].p = HORUS and 1 or nil
 	if config2[17].p == nil then
 		config2[17].p = (not data.showCurr or config[23].v ~= 0) and 1 or nil
 		config2[18].p = config2[17].p

--- a/src/SCRIPTS/TELEMETRY/iNav/pilot.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/pilot.lua
@@ -25,7 +25,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			local yd = math.cos(roll1) * r
 			local x1, y1, x2, y2 = x - xd, y + yd, x + xd, y - yd
 			if (y1 > 15 or y2 > 15) and (y1 < 56 or y2 < 56) then
-				line(x1, y1, x2, y2, SMLCD and DOTTED or (adj % 10 == 0 and SOLID or DOTTED), SMLCD and 0 or (adj > 0 and GREY_DEFAULT or 0))
+				line(x1, y1, x2, y2, SMLCD and DOTTED or (adj % 10 == 0 and SOLID or DOTTED), (SMLCD or config[35].v == 1) and 0 or (adj > 0 and GREY_DEFAULT or 0))
 				if not SMLCD and adj % 10 == 0 and adj ~= 0 and y1 > 15 and y1 < 56 then
 					text(x1 - 2, y1 - 3, math.abs(adj), SMLSIZE + RIGHT)
 				end
@@ -42,12 +42,12 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			for x = LEFT_POS + 1, RIGHT_POS - 1 do
 				local yy = y + 0.5
 				if (not upsideDown and yy < 64) or (upsideDown and yy > 7) then
-					line(x, math.min(math.max(yy, 8), 63), x, upsideDown and 8 or 63, SOLID, SMLCD and 0 or GREY_DEFAULT)
+					line(x, math.min(math.max(yy, 8), 63), x, upsideDown and 8 or 63, SOLID, (SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT)
 				end
 				y = y + a
 			end
 		elseif (y1 > 15 or y2 > 15) and (y1 < 56 or y2 < 56) then
-			line(x1, y1, x2, y2, SMLCD and DOTTED or (adj % 10 == 0 and SOLID or DOTTED), SMLCD and 0 or (adj > 0 and GREY_DEFAULT or 0))
+			line(x1, y1, x2, y2, SMLCD and DOTTED or (adj % 10 == 0 and SOLID or DOTTED), (SMLCD or config[35].v == 1) and 0 or (adj > 0 and GREY_DEFAULT or 0))
 			if not SMLCD and adj % 10 == 0 and adj ~= 0 and y1 > 15 and y1 < 56 then
 				text(x1 - 2, y1 - 3, math.abs(adj), SMLSIZE + RIGHT)
 			end
@@ -81,7 +81,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		if data.headingHold then
 			fill((x2 + x3) * 0.5 - 1, (y2 + y3) * 0.5 - 1, 3, 3, SOLID)
 		else
-			line(x2, y2, x3, y3, SMLCD and DOTTED or SOLID, FORCE + (SMLCD and 0 or GREY_DEFAULT))
+			line(x2, y2, x3, y3, SMLCD and DOTTED or SOLID, FORCE + ((SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT))
 		end
 		line(x1, y1, x2, y2, SOLID, FORCE)
 		line(x1, y1, x3, y3, SOLID, FORCE)
@@ -198,7 +198,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	for x = LEFT_POS + 1, RIGHT_POS - 1 do
 		local yy = y + 0.5
 		if (not upsideDown and yy < 64) or (upsideDown and yy > 7) then
-			line(x, math.min(math.max(yy, 8), 63), x, upsideDown and 8 or 63, SOLID, SMLCD and 0 or GREY_DEFAULT)
+			line(x, math.min(math.max(yy, 8), 63), x, upsideDown and 8 or 63, SOLID, (SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT)
 		end
 		y = y + a
 	end
@@ -210,7 +210,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		if (not upsideDown and yy < 64) or (upsideDown and yy > 7) then
 			local t = upsideDown and 8 or math.min(math.max(yy, 8), 63)
 			local h = upsideDown and math.min(math.max(yy, 8), 64) - t or 65 - t
-			fill(x, t, width, h, GREY_DEFAULT)
+			fill(x, t, width, h, (SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT)
 		end
 		y = y + a * width
 	end
@@ -225,7 +225,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 					lastx = x
 					break
 				end
-				fill(x, 8, width, h, GREY_DEFAULT)
+				fill(x, 8, width, h, (SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT)
 			end
 		else
 			if y < 64 then
@@ -234,13 +234,13 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 					lastx = x
 					break
 				end
-				fill(x, t, width, 65 - t, GREY_DEFAULT)
+				fill(x, t, width, 65 - t, (SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT)
 			end
 		end
 		y = y + a * width
 	end
 	if lastx then
-		fill(lastx, 8, RIGHT_POS - lastx, 57, GREY_DEFAULT)
+		fill(lastx, 8, RIGHT_POS - lastx, 57, (SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT)
 	end
 	]]
 	local inside = SMLCD and 6 or 13
@@ -289,7 +289,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	if config[7].v % 2 == 1 then
 		line(RIGHT_POS, 8, RIGHT_POS, 63, SOLID, FORCE)
 		line(RIGHT_POS + (SMLCD and 4 or 6), 8, RIGHT_POS + (SMLCD and 4 or 6), 63, SOLID, FORCE)
-		line(RIGHT_POS + 1, 35, RIGHT_POS + (SMLCD and 3 or 5), 35, SMLCD and DOTTED or SOLID, SMLCD and 0 or GREY_DEFAULT)
+		line(RIGHT_POS + 1, 35, RIGHT_POS + (SMLCD and 3 or 5), 35, SMLCD and DOTTED or SOLID, (SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT)
 		if data.armed then
 			tmp = math.log(1 + math.min(math.abs(0.6 * (data.vspeed_unit == 6 and data.vspeed * 0.3048 or data.vspeed)), 10)) * (data.vspeed < 0 and -1 or 1)
 			local y1 = 36 - (tmp * 11)
@@ -313,9 +313,9 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		if data.crsf == false then
 			text(LCD_W + 1, config[22].v == 0 and 32 or 22, "HDOP", RIGHT + SMLSIZE)
 		end
-		hdopGraph(LCD_W - 12, config[22].v == 0 and (data.crsf and 37 or 24) or 31, MIDSIZE, SMLCD)
+		hdopGraph(LCD_W - 12, config[22].v == 0 and (data.crsf and 37 or 24) or 31, MIDSIZE, (SMLCD or config[35].v == 1))
 	else
-		hdopGraph(LCD_W - 39, data.crsf and 24 or 10, MIDSIZE, SMLCD)
+		hdopGraph(LCD_W - 39, data.crsf and 24 or 10, MIDSIZE, (SMLCD or config[35].v == 1))
 		if data.crsf == false then
 			text(LCD_W - (config[22].v == 0 and 24 or 25), config[22].v == 0 and 18 or 20, "HDOP", RIGHT + SMLSIZE)
 		end

--- a/src/SCRIPTS/TELEMETRY/iNav/radar.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/radar.lua
@@ -112,7 +112,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 				fill((x2 + x3) * 0.5 - 1, (y2 + y3) * 0.5 - 1, 3, 3, SOLID)
 			end
 		else
-			line(x2, y2, x3, y3, SMLCD and DOTTED or SOLID, FORCE + (SMLCD and 0 or GREY_DEFAULT))
+			line(x2, y2, x3, y3, SMLCD and DOTTED or SOLID, FORCE + ((SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT))
 		end
 		line(x1, y1, x2, y2, SOLID, FORCE)
 		line(x1, y1, x3, y3, SOLID, FORCE)
@@ -122,7 +122,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	if config[7].v % 2 == 1 then
 		line(RIGHT_POS, 8, RIGHT_POS, 63, SOLID, FORCE)
 		line(RIGHT_POS + (SMLCD and 4 or 6), 8, RIGHT_POS + (SMLCD and 4 or 6), 63, SOLID, FORCE)
-		line(RIGHT_POS + 1, 35, RIGHT_POS + (SMLCD and 3 or 5), 35, SMLCD and DOTTED or SOLID, SMLCD and 0 or GREY_DEFAULT)
+		line(RIGHT_POS + 1, 35, RIGHT_POS + (SMLCD and 3 or 5), 35, SMLCD and DOTTED or SOLID, (SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT)
 		if data.armed then
 			tmp = math.log(1 + math.min(math.abs(0.6 * (data.vspeed_unit == 6 and data.vspeed * 0.3048 or data.vspeed)), 10)) * (data.vspeed < 0 and -1 or 1)
 			local y1 = 36 - (tmp * 11)
@@ -146,9 +146,9 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		if data.crsf == false then
 			text(LCD_W + 1, config[22].v == 0 and 32 or 22, "HDOP", RIGHT + SMLSIZE)
 		end
-		hdopGraph(LCD_W - 12, config[22].v == 0 and (data.crsf and 37 or 24) or 31, MIDSIZE, SMLCD)
+		hdopGraph(LCD_W - 12, config[22].v == 0 and (data.crsf and 37 or 24) or 31, MIDSIZE, (SMLCD or config[35].v == 1))
 	else
-		hdopGraph(LCD_W - 39, data.crsf and 24 or 10, MIDSIZE, SMLCD)
+		hdopGraph(LCD_W - 39, data.crsf and 24 or 10, MIDSIZE, (SMLCD or config[35].v == 1))
 		if data.crsf == false then
 			text(LCD_W - (config[22].v == 0 and 24 or 25), config[22].v == 0 and 18 or 20, "HDOP", RIGHT + SMLSIZE)
 		end

--- a/src/SCRIPTS/TELEMETRY/iNav/view.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/view.lua
@@ -16,7 +16,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		if data.headingHold then
 			fill((x2 + x3) * 0.5 - 1.5, (y2 + y3) * 0.5 - 1.5, 4, 4, SOLID)
 		else
-			line(x2, y2, x3, y3, SMLCD and DOTTED or SOLID, FORCE + (SMLCD and 0 or GREY_DEFAULT))
+			line(x2, y2, x3, y3, SMLCD and DOTTED or SOLID, FORCE + ((SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT))
 		end
 	end
 
@@ -55,7 +55,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	else
 		text(tmp, 17, math.floor(data.gpsAlt + 0.5) .. units[data.gpsAlt_unit], gpsFlags)
 	end
-	hdopGraph(RIGHT_POS - 30, data.crsf and 17 or 9, SMLSIZE, SMLCD)
+	hdopGraph(RIGHT_POS - 30, data.crsf and 17 or 9, SMLSIZE, (SMLCD or config[35].v == 1))
 	icons.gps(RIGHT_POS - 17, data.crsf and 17 or 9)
 	text(RIGHT_POS - (data.telem and 0 or 1), data.crsf and 17 or 9, data.satellites % 100, SMLSIZE + RIGHT + telemFlag)
 
@@ -85,7 +85,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 				local rad1 = math.rad(bearing)
 				local x1 = math.floor(math.sin(rad1) * 10 + 0.5) + X_CNTR_2
 				local y1 = 19 - math.floor(math.cos(rad1) * 10 + 0.5)
-				line(X_CNTR_2, 19, x1, y1, SMLCD and DOTTED or SOLID, FORCE + (SMLCD and 0 or GREY_DEFAULT))
+				line(X_CNTR_2, 19, x1, y1, SMLCD and DOTTED or SOLID, FORCE + ((SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT))
 				fill(x1 - 1, y1 - 1, 3, 3, ERASE)
 				fill(x1 - 1, y1 - 1, 3, 3, SOLID)
 			end
@@ -130,7 +130,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		tmp = math.max(math.min(math.ceil(data.altitude / config[6].v * 46), 46), 0)
 		fill(l + 1, 56 - tmp, w - 2, tmp, INVERS)
 		tmp = 56 - math.max(math.min(math.ceil(data.altitudeMax / config[6].v * 46), 46), 0)
-		line(l + 1, tmp, l + w - 2, tmp, SOLID, GREY_DEFAULT)
+		line(l + 1, tmp, l + w - 2, tmp, SOLID, (SMLCD or config[35].v == 1) and 0 or GREY_DEFAULT)
 		text(l + 1, 58, config[7].v % 2 == 1 and "A" or "Alt", SMLSIZE)
 	end
 


### PR DESCRIPTION
This adds a 'greyscale' on/off toggle user configuration option for monochrome displays. It allows the user to disable greyscale and force high-contrast B&W mode, for LCD's that have issues with displaying grey shading. 