### PR TITLE
Fix 'not enough memory' on flight reset

### DIFF
--- a/src/SCRIPTS/TELEMETRY/iNav.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav.lua
@@ -410,8 +410,10 @@ function inav.background()
 		-- Initialize variables on flight reset (uses timer3)
 		tmp = model.getTimer(2)
 		if tmp.value == 0 then
-		   loadScript(FILE_PATH .. "load" .. ext, env)(config, data, FILE_PATH)
+			loadScript(FILE_PATH .. "load" .. ext, env)(config, data, FILE_PATH)
+			collectgarbage()
 			loadScript(FILE_PATH .. "reset" .. ext, env)(data)
+			collectgarbage()
 			tmp.value = 3600
 			model.setTimer(2, tmp)
 		end

--- a/src/SCRIPTS/TELEMETRY/iNav/load.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/load.lua
@@ -13,6 +13,8 @@ if fh ~= nil then
    end
    io.close(fh)
 end
+fh = nil
+collectgarbage()
 
 -- Look for language override
 fh = io.open(FILE_PATH .. "cfg/lang.dat")
@@ -22,6 +24,8 @@ if fh ~= nil then
    data.lang = tmp
    data.voice = tmp
 end
+fh = nil
+collectgarbage()
 
 local log = getDateTime()
 
@@ -33,18 +37,20 @@ for days = 1, 15 do
    local fh = io.open(path .. logDate .. ".csv")
    if fh ~= nil then
       io.close(fh)
+      fh = nil
+      collectgarbage()
       config[34].x = config[34].x + 1
       config[34].l[config[34].x] = logDate
-      collectgarbage()
       if config[34].x == 5 then break end
    end
+   
    log.day = log.day - 1
    if log.day == 0 then
       log.day = 31
       log.mon = log.mon - 1
       if log.mon == 0 then
-	 log.mon = 12
-	 log.year = log.year - 1
+	   log.mon = 12
+	   log.year = log.year - 1
       end
    end
 end


### PR DESCRIPTION
The script will crash w/ the 'not enough memory' error on Taranis when selecting 'Reset Flight' radio option. This fix adds some garbage collection to prevent the crash. Tested & confirmed working on Taranis X9D+.