### PR TITLE
Fix maximum symbol.

### DIFF
--- a/src/SCRIPTS/TELEMETRY/iNav/alt.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/alt.lua
@@ -55,7 +55,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	end
 	-- Min/Max
 	if not data.showDir and data.showMax then
-		text(RIGHT_POS, 9, "\192", SMLSIZE + RIGHT)
+		icons.up(RIGHT_POS - 6, 9)
 	end
 
 	if data.startup == 0 then

--- a/src/SCRIPTS/TELEMETRY/iNav/func_t.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/func_t.lua
@@ -93,4 +93,24 @@ function icons.home(x, y)
 	lcd.drawPoint(x + 3, y + 4)
 end
 
+function icons.up(x, y)
+	lcd.drawPoint(x + 2, y + 0)
+	lcd.drawPoint(x + 1, y + 1)
+	lcd.drawPoint(x + 2, y + 1)
+	lcd.drawPoint(x + 3, y + 1)
+	lcd.drawPoint(x + 0, y + 2)
+	lcd.drawPoint(x + 4, y + 2)
+	line(x + 2, y + 3, x + 2, y + 6, SOLID, 0)
+end
+
+function icons.down(x, y)
+	line(x + 2, y, x + 2, y + 3, SOLID, 0)
+	lcd.drawPoint(x + 0, y + 4)
+	lcd.drawPoint(x + 4, y + 4)
+	lcd.drawPoint(x + 1, y + 5)
+	lcd.drawPoint(x + 2, y + 5)
+	lcd.drawPoint(x + 3, y + 5)
+	lcd.drawPoint(x + 2, y + 6)
+end
+
 return title, gpsDegMin, hdopGraph, icons, rect

--- a/src/SCRIPTS/TELEMETRY/iNav/pilot.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/pilot.lua
@@ -129,8 +129,8 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 			icons.home(home, tmp)
 		end
 	elseif data.showMax then
-		text(LEFT_POS + 21, 33, "\192", SMLSIZE)
-		text(RIGHT_POS - 22, 33, "\192", SMLSIZE + RIGHT)
+		icons.up(LEFT_POS + 21, 32)
+		icons.up(RIGHT_POS - 28, 32)
 	end
 
 	-- Heading part 1

--- a/src/SCRIPTS/TELEMETRY/iNav/radar.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/radar.lua
@@ -62,7 +62,7 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 	end
 	-- Min/Max
 	if not data.showDir and data.showMax then
-		text(RIGHT_POS, 9, "\192", SMLSIZE + RIGHT)
+		icons.up(RIGHT_POS - 6, 9)
 	end
 
 	-- Radar

--- a/src/SCRIPTS/TELEMETRY/iNav/view.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/view.lua
@@ -24,7 +24,11 @@ local function view(data, config, modes, dir, units, labels, gpsDegMin, hdopGrap
 		if data.showMax and d > 0 then
 			vc = vm
 			text(0, y, string.sub(txt, 1, 3), SMLSIZE)
-			text(15, y, d == 1 and "\192" or "\193", SMLSIZE)
+			if d == 1 then
+				icons.up(15, y)
+			else
+				icons.down(15, y)
+			end
 		else
 			text(0, y, txt, SMLSIZE)
 		end


### PR DESCRIPTION
On Taranis, it is possible to switch between displaying actual and maximum values, using the rotary control. The symbol is displayed to signify the values are maximum/minimum. This is implemented with drawing text with special characters "\192" and "\193".

On my version and hardware, edgetx v2.10.5, opentx-telemetry-widget 2.2.5, transmitter taranis qx7 access, the characters are not displayed - the space on display is blank.

I propose to replace the special characters with up and down arrow drawed with "lcd.drawLine" and "lcd.drawPixel".