### PR TITLE
Initial CRSF data delay - to allow cell voltage to stabilise and fuel be calculated correctly. 

### DIFF
--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -89,7 +89,7 @@ Note also that on some of the smaller B&W radios (Boxer, Zorro, TX12) with a rol
   * **GPS** - GPS coordinates as decimal or degrees/minutes format (default: Decimal)
   * **Playback Log** - Playback telemetry log files (latest 5 logs from the last 2 weeks) **[[help](../Configuration-Settings/#playback-telemetry-log-files)]**
   * **Greyscale Gfx** - Turn on/off the use of greyscale display graphics (only for monochrome displays)
-  * **CRSF data delay** - Set the delay before CRSF telemetry values are used after the FC is initialised 
+  * **CRSF Fuel Delay** - Set the delay before CRSF telemetry values are used for fuel calc, after the FC is initialised 
 
 ### Suggested Battery Settings
 #### Voltage and Current Calibration

--- a/docs/Configuration-Settings.md
+++ b/docs/Configuration-Settings.md
@@ -89,6 +89,7 @@ Note also that on some of the smaller B&W radios (Boxer, Zorro, TX12) with a rol
   * **GPS** - GPS coordinates as decimal or degrees/minutes format (default: Decimal)
   * **Playback Log** - Playback telemetry log files (latest 5 logs from the last 2 weeks) **[[help](../Configuration-Settings/#playback-telemetry-log-files)]**
   * **Greyscale Gfx** - Turn on/off the use of greyscale display graphics (only for monochrome displays)
+  * **CRSF data delay** - Set the delay before CRSF telemetry values are used after the FC is initialised 
 
 ### Suggested Battery Settings
 #### Voltage and Current Calibration

--- a/src/SCRIPTS/TELEMETRY/iNav/config.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/config.lua
@@ -37,6 +37,7 @@ local config = {
 	{ o = 26, c = 1, v = 0 }, -- Roll Scale - 33
 	{ o = 34, c = 1, v = 0, l = {[0] = "?"}, x = -1 }, -- Review Log Date - 34
 	{ o = 35, c = 1, v = 0 }, -- Greyscale toggle - 35
+	{ o = 36, c = 2, v = 5, x = 20 }, -- CRSF data delay - 36
 }
 
 for i = 1, #config do

--- a/src/SCRIPTS/TELEMETRY/iNav/config.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/config.lua
@@ -37,7 +37,7 @@ local config = {
 	{ o = 26, c = 1, v = 0 }, -- Roll Scale - 33
 	{ o = 34, c = 1, v = 0, l = {[0] = "?"}, x = -1 }, -- Review Log Date - 34
 	{ o = 35, c = 1, v = 0 }, -- Greyscale toggle - 35
-	{ o = 36, c = 2, v = 5, x = 20 }, -- CRSF data delay - 36
+	{ o = 36, c = 2, v = 2.0, d = true, x = 5.0 }, -- CRSF Fuel Delay - 36
 }
 
 for i = 1, #config do

--- a/src/SCRIPTS/TELEMETRY/iNav/config.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/config.lua
@@ -37,7 +37,8 @@ local config = {
 	{ o = 26, c = 1, v = 0 }, -- Roll Scale - 33
 	{ o = 34, c = 1, v = 0, l = {[0] = "?"}, x = -1 }, -- Review Log Date - 34
 	{ o = 35, c = 1, v = 0 }, -- Greyscale toggle - 35
-	{ o = 36, c = 2, v = 2.0, d = true, x = 5.0 }, -- CRSF Fuel Delay - 36
+	{ o = 36, c = 1, v = 0 }, -- Horizon Mode - 36
+	{ o = 37, c = 2, v = 2.0, d = true, x = 5.0 }, -- CRSF Fuel Delay - 37
 }
 
 for i = 1, #config do

--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -20,16 +20,6 @@ config[21].v = 2.5
 config[22].v = 0
 config[23].x = 1
 
-local counter = ... -- debug print
-counter.loop = 0 -- debug print
-setSerialBaudrate(115200) -- debug print
-
-local function debug_print_text(str) -- debug print
-	local full_str = string.format("Lo: %4d - %s", counter.loop, str)	 
-	print(full_str)
-	serialWrite(full_str .. "\r\n")
-end
-
 local function crsf(data)
    local vtest
    vtest =  getValue(data.rssi_id)
@@ -66,24 +56,20 @@ local function crsf(data)
 
 	data.fuelRaw = data.fuel
 	if data.showFuel and config[23].v == 0 then
-		if config[36].v == 0 and data.voltStab == false then data.voltStab = true end -- No voltstab timer set
+		if config[36].v == 0 and data.voltStab == false then data.voltStab = true end
 		if data.voltStab then
 			if data.fuelEst == -1 and data.cell > 0 then
 				if data.fuel < 25 and config[29].v - data.cell >= 0.2 then
-					data.fuelEst = math.max(math.min(1 - (data.cell - config[2].v + 0.1) / (config[29].v - config[2].v), 1), 0) * config[27].v
-					debug_print_text(string.format("fuelEst - Fuel Calculated @ %d", data.fuelEst)) -- debug print
+					data.fuelEst = math.max(math.min(1 - (data.cell - config[2].v + 0.1) / (config[29].v - config[2].v), 1), 0) * config[27].v				
 				else
 					data.fuelEst = 0
-					debug_print_text("fuelEst - Batt Full") -- debug print
 				end
 			end
 			data.fuel = math.max(math.min(math.floor((1 - (data.fuel + data.fuelEst) / config[27].v) * 100 + 0.5), 100), 0)
 		else
 			data.fuel = -1 -- fuel set to -1 for obvious feedback that fuel is not yet calculated
 			if data.cell_prev ~= data.cell then
-				debug_print_text(string.format("Cell change: %.2f -> %.2f", data.cell_prev, data.cell))
-				if data.cell > data.cell_prev then -- voltage is higher, start a timer 
-					debug_print_text("fuelEst Reset") -- debug print
+				if data.cell > data.cell_prev then
 					data.voltTimer = getTime()
 				end
 				data.cell_prev = data.cell
@@ -92,7 +78,6 @@ local function crsf(data)
 				-- if no voltage increase in the set time, the pack voltage reading is taken as stabilised. 
 				data.voltStab = true
 				data.voltTimer = (getTime() - data.voltTimer)
-				debug_print_text(string.format("voltStab - Time %.2f s", (data.voltTimer/100)))
 			end
 		end
 	end
@@ -151,7 +136,7 @@ local function crsf(data)
 			data.mode = 40004
 		end
 	end
-	counter.loop = counter.loop + 1	-- debug print
+
 	return 0
 end
 

--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -71,7 +71,7 @@ local function crsf(data)
 			if data.fuelEst == -1 and data.cell > 0 then
 				if data.fuel < 25 and config[29].v - data.cell >= 0.2 then
 					data.fuelEst = math.max(math.min(1 - (data.cell - config[2].v + 0.1) / (config[29].v - config[2].v), 1), 0) * config[27].v
-					debug_print_text("fuelEst - Fuel Calculated") -- debug print
+					debug_print_text(string.format("fuelEst - Fuel Calculated @ %d", data.fuelEst)) -- debug print
 				else
 					data.fuelEst = 0
 					debug_print_text("fuelEst - Batt Full") -- debug print
@@ -81,7 +81,7 @@ local function crsf(data)
 		else
 			data.fuel = -1 -- fuel set to -1 for obvious feedback that fuel is not yet calculated
 			if data.cell_prev ~= data.cell then
-				debug_print_text("Cell change")
+				debug_print_text(string.format("Cell change: %.2f -> %.2f", data.cell_prev, data.cell))
 				if data.cell > data.cell_prev then -- voltage is higher, start a timer 
 					debug_print_text("fuelEst Reset") -- debug print
 					data.voltTimer = getTime()
@@ -89,11 +89,10 @@ local function crsf(data)
 				data.cell_prev = data.cell
 			end
 			if data.voltTimer > 0 and ( data.voltTimer and (getTime() - data.voltTimer) >= (config[36].v * 100) ) then
-				-- if no voltage increase in the set time, the pack voltage reading is taken as stabilised. 				
-				debug_print_text("crsfStab")
+				-- if no voltage increase in the set time, the pack voltage reading is taken as stabilised. 
 				data.voltStab = true
 				data.voltTimer = (getTime() - data.voltTimer)
-				debug_print_text(tostring(data.voltTimer)) -- debug print
+				debug_print_text(string.format("voltStab - Time %.2f s", (data.voltTimer/100)))
 			end
 		end
 	end

--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -13,11 +13,22 @@ data.fpv_id = getTelemetryId("Hdg")
 data.tpwr = 0
 data.rfmd = "--"
 data.fuelRaw = 0
+
 config[9].v = 0
 config[14].v = 0
 config[21].v = 2.5
 config[22].v = 0
 config[23].x = 1
+
+local counter = ... -- debug print
+counter.loop = 0 -- debug print
+setSerialBaudrate(115200) -- debug print
+
+local function debug_print_text(str) -- debug print
+	local full_str = string.format("Lo: %4d - %s", counter.loop, str)	 
+	print(full_str)
+	serialWrite(full_str .. "\r\n")
+end
 
 local function crsf(data)
    local vtest
@@ -33,15 +44,9 @@ local function crsf(data)
 	    data.rssi = 0
 	    data.tpwr = 0
 	    data.telem = false
-	    data.crsfReady = 0
 	    return 0
 	 end
       end
-   end
-   
-   if data.crsfReady < config[36].v then 
-    data.crsfReady = data.crsfReady + 1
-    return 0 
    end
 
    if data.rssi == 99 then data.rssi = 100 end
@@ -58,16 +63,39 @@ local function crsf(data)
 	data.heading = math.deg(getValue(data.hdg_id))
 	if data.fpv_id > -1 then data.fpv = getValue(data.fpv_id) * 10 end
 	]]
+
 	data.fuelRaw = data.fuel
 	if data.showFuel and config[23].v == 0 then
-		if data.fuelEst == -1 and data.cell > 0 then
-			if data.fuel < 25 and config[29].v - data.cell >= 0.2 then
-				data.fuelEst = math.max(math.min(1 - (data.cell - config[2].v + 0.1) / (config[29].v - config[2].v), 1), 0) * config[27].v
-			else
-				data.fuelEst = 0
+		if config[36].v == 0 and data.voltStab == false then data.voltStab = true end -- No voltstab timer set
+		if data.voltStab then
+			if data.fuelEst == -1 and data.cell > 0 then
+				if data.fuel < 25 and config[29].v - data.cell >= 0.2 then
+					data.fuelEst = math.max(math.min(1 - (data.cell - config[2].v + 0.1) / (config[29].v - config[2].v), 1), 0) * config[27].v
+					debug_print_text("fuelEst - Fuel Calculated") -- debug print
+				else
+					data.fuelEst = 0
+					debug_print_text("fuelEst - Batt Full") -- debug print
+				end
+			end
+			data.fuel = math.max(math.min(math.floor((1 - (data.fuel + data.fuelEst) / config[27].v) * 100 + 0.5), 100), 0)
+		else
+			data.fuel = -1 -- fuel set to -1 for obvious feedback that fuel is not yet calculated
+			if data.cell_prev ~= data.cell then
+				debug_print_text("Cell change")
+				if data.cell > data.cell_prev then -- voltage is higher, start a timer 
+					debug_print_text("fuelEst Reset") -- debug print
+					data.voltTimer = getTime()
+				end
+				data.cell_prev = data.cell
+			end
+			if data.voltTimer > 0 and ( data.voltTimer and (getTime() - data.voltTimer) >= (config[36].v * 100) ) then
+				-- if no voltage increase in the set time, the pack voltage reading is taken as stabilised. 				
+				debug_print_text("crsfStab")
+				data.voltStab = true
+				data.voltTimer = (getTime() - data.voltTimer)
+				debug_print_text(tostring(data.voltTimer)) -- debug print
 			end
 		end
-		data.fuel = math.max(math.min(math.floor((1 - (data.fuel + data.fuelEst) / config[27].v) * 100 + 0.5), 100), 0)
 	end
 	data.fm = getValue(data.fm_id)
 	data.modePrev = data.mode
@@ -124,7 +152,7 @@ local function crsf(data)
 			data.mode = 40004
 		end
 	end
-
+	counter.loop = counter.loop + 1	-- debug print
 	return 0
 end
 

--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -39,7 +39,7 @@ local function crsf(data)
       end
    end
    
-   if data.crsfReady < 5 then 
+   if data.crsfReady < config[36].v then 
     data.crsfReady = data.crsfReady + 1
     return 0 
    end

--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -33,9 +33,15 @@ local function crsf(data)
 	    data.rssi = 0
 	    data.tpwr = 0
 	    data.telem = false
+	    data.crsfReady = 0
 	    return 0
 	 end
       end
+   end
+   
+   if data.crsfReady < 5 then 
+    data.crsfReady = data.crsfReady + 1
+    return 0 
    end
 
    if data.rssi == 99 then data.rssi = 100 end

--- a/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/crsf.lua
@@ -56,7 +56,7 @@ local function crsf(data)
 
 	data.fuelRaw = data.fuel
 	if data.showFuel and config[23].v == 0 then
-		if config[36].v == 0 and data.voltStab == false then data.voltStab = true end
+		if config[37].v == 0 and data.voltStab == false then data.voltStab = true end
 		if data.voltStab then
 			if data.fuelEst == -1 and data.cell > 0 then
 				if data.fuel < 25 and config[29].v - data.cell >= 0.2 then
@@ -74,7 +74,7 @@ local function crsf(data)
 				end
 				data.cell_prev = data.cell
 			end
-			if data.voltTimer > 0 and ( data.voltTimer and (getTime() - data.voltTimer) >= (config[36].v * 100) ) then
+			if data.voltTimer > 0 and ( data.voltTimer and (getTime() - data.voltTimer) >= (config[37].v * 100) ) then
 				-- if no voltage increase in the set time, the pack voltage reading is taken as stabilised. 
 				data.voltStab = true
 				data.voltTimer = (getTime() - data.voltTimer)

--- a/src/SCRIPTS/TELEMETRY/iNav/menu.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/menu.lua
@@ -45,7 +45,7 @@ local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId,
 		{ t = "Roll Scale",       l = 1 }, -- 33
 		{ t = "Playback Log",     l = config[34].l }, -- 34
 		{ t = "Greyscale Gfx",    l = {[0] = "On", "Off"} }, -- 35
-		{ t = "CRSF data delay",  m = 0, a = " frames" }, -- 36
+		{ t = "CRSF Fuel Delay",  m = 0, i = 0.5, a = "S" }, -- 36
 	}
 
 	-- Import language changes

--- a/src/SCRIPTS/TELEMETRY/iNav/menu.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/menu.lua
@@ -45,7 +45,8 @@ local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId,
 		{ t = "Roll Scale",       l = 1 }, -- 33
 		{ t = "Playback Log",     l = config[34].l }, -- 34
 		{ t = "Greyscale Gfx",    l = {[0] = "On", "Off"} }, -- 35
-		{ t = "CRSF Fuel Delay",  m = 0, i = 0.5, a = "S" }, -- 36
+		{ t = "Horizon Mode",     l = {[0] = "Standard", "Fixed"} }, -- 36
+		{ t = "CRSF Fuel Delay",  m = 0, i = 0.5, a = "s" }, -- 37
 	}
 
 	-- Import language changes

--- a/src/SCRIPTS/TELEMETRY/iNav/menu.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/menu.lua
@@ -45,6 +45,7 @@ local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId,
 		{ t = "Roll Scale",       l = 1 }, -- 33
 		{ t = "Playback Log",     l = config[34].l }, -- 34
 		{ t = "Greyscale Gfx",    l = {[0] = "On", "Off"} }, -- 35
+		{ t = "CRSF data delay",  m = 0, a = " frames" }, -- 36
 	}
 
 	-- Import language changes
@@ -80,6 +81,8 @@ local function view(data, config, units, lang, event, gpsDegMin, getTelemetryId,
 	config2[24].p = data.crsf and 1 or (config[7].v < 2 and 1 or nil)
 	config2[27].p = (not data.crsf or config[23].v > 0) and 1 or nil
 	config2[35].p = HORUS and 1 or nil
+	config2[36].p = not data.crsf and 1 or nil
+
 	if config2[17].p == nil then
 		config2[17].p = (not data.showCurr or config[23].v ~= 0) and 1 or nil
 		config2[18].p = config2[17].p

--- a/src/SCRIPTS/TELEMETRY/iNav/reset.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/reset.lua
@@ -1,5 +1,6 @@
 local data = ...
 
+data.crsfReady = 0
 data.armed = false
 data.startup = 1
 data.timerStart = 0

--- a/src/SCRIPTS/TELEMETRY/iNav/reset.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav/reset.lua
@@ -1,6 +1,8 @@
 local data = ...
 
-data.crsfReady = 0
+data.voltTimer = 0
+data.voltStab = false
+data.cell_prev = 0.0
 data.armed = false
 data.startup = 1
 data.timerStart = 0


### PR DESCRIPTION
This is a fix for issue #174 and discussions held on Discord. See https://discord.com/channels/791437907478577172/1493986783313133740/1497692570384601108 for further info. 

Adds a configurable delay to CRSF data when the FC is first booted. This is to allow the voltage reading from the FC to stabilise and report the correct pack voltage.  

Tested on cold starting with fully charged and partially charged packs, and resetting between packs with use of the timer 3 reset mechanic. 

Default value of 5. If set to 0 in config, the delay is ignored. 