### PR TITLE
Bump version to 2.4, ensure both release zips build automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           echo "BUILD_SUFFIX=${BUILD_SUFFIX}" >> $GITHUB_ENV
           echo "BUILD_NAME=LuaTelemetry-${VERSION}-${BUILD_SUFFIX}" >> $GITHUB_ENV
       - name: Build dist
-        run: make dist
+        run: make dist dist-lua
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "[0-9]+.[0-9]+*"
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -12,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get -y install zip build-essential
       - name: Build dist
-        run: make dist
+        run: make dist dist-lua
       - name: Upload release
         uses: svenstaro/upload-release-action@v1-release
         with:

--- a/src/SCRIPTS/TELEMETRY/iNav.lua
+++ b/src/SCRIPTS/TELEMETRY/iNav.lua
@@ -2,7 +2,7 @@
 -- Docs: https://github.com/iNavFlight/OpenTX-Telemetry-Widget
 
 local zone, options = ...
-local VERSION = "2.3.0"
+local VERSION = "2.4"
 local FILE_PATH = "/SCRIPTS/TELEMETRY/iNav/"
 local SMLCD = LCD_W < 212
 local HORUS = LCD_W >= 480 or LCD_H >= 480


### PR DESCRIPTION
## Summary
The `2.4` release was tagged and published without any assets attached, and the in-app `VERSION` string still said `2.3.0`. Root causes:

- `local VERSION = "2.3.0"` in `src/SCRIPTS/TELEMETRY/iNav.lua` was never bumped before tagging, so the widget itself would report the wrong version even once assets were added.
- `release.yml` only runs `make dist`, which builds the compiled-lua zip. It never ran `make dist-lua` (the uncompiled source zip needed for EdgeTX 2.11+), so that second asset — present on past releases — had to be built and uploaded by hand every time.
- The `release.yml` tag trigger is `v*` only, but published tags haven't been consistent (`v2.2.0`, `v.2.3.0`, and now plain `2.4`), so a tag like `2.4` never fires the workflow at all.

## Changes
- Bump `VERSION` to `2.4` to match the published tag.
- `release.yml` / `ci.yml`: build both `make dist` and `make dist-lua` so both zips are produced (and uploaded, for `release.yml`) automatically.
- `release.yml`: also trigger on bare numeric version tags (`[0-9]+.[0-9]+*`), not just `v*`.

## Verified
- Built both zips locally from this branch (which includes the `tx15.lua`/`tx16s.lua` 480x320 and 800x480 layouts from #190/#202/#203) and confirmed both are present in the compiled zip and the version string is `2.4` in the source zip.
- `make dist dist-lua` (the exact command the workflows now run) succeeds in one invocation.

## Note
The already-published `2.4` release currently points at 4c6af52 (before this version bump) and has no assets. Assets built from this branch will be attached to that release separately; not moving the tag since the release has no assets yet to conflict with.

## Test plan
- [ ] CI (`ci.yml`) run on this PR produces both a compiled and a source zip artifact